### PR TITLE
Fix 404 log noise

### DIFF
--- a/server.js
+++ b/server.js
@@ -338,9 +338,11 @@ app.use('/api/market', require('./server/routes/market-api'));
 
 // 404 handler
 app.use((req, res) => {
-  console.log('404 Not Found:', req.method, req.url);
-  console.log('Referrer:', req.get('Referrer') || 'None');
-  console.log('User Agent:', req.get('User-Agent'));
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('404 Not Found:', req.method, req.url);
+    console.log('Referrer:', req.get('Referrer') || 'None');
+    console.log('User Agent:', req.get('User-Agent'));
+  }
 
   res.status(404).render('error', {
     title: '404 - Page Not Found',


### PR DESCRIPTION
## Summary
- silence noisy `console.log` statements in the 404 handler

## Testing
- `npm run lint`
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450dc2b87c832f8481f7171aef5da6

## Summary by Sourcery

Bug Fixes:
- Suppress 404 handler console logs in production to reduce log noise.