### PR TITLE
Add user auth tests

### DIFF
--- a/tests/server/routes/index.test.js
+++ b/tests/server/routes/index.test.js
@@ -7,12 +7,17 @@ const express = require('express');
 // Mock dependencies
 jest.mock('../../../server/models/User', () => ({
   findRecent: jest.fn().mockResolvedValue([
-    { username: 'testuser1', displayName: 'Test User 1' },
-    { username: 'testuser2', displayName: 'Test User 2' }
+    { username: 'testuser1', displayName: 'Test User 1', lastActive: new Date() },
+    { username: 'testuser2', displayName: 'Test User 2', lastActive: new Date() }
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2),
+  find: jest.fn().mockResolvedValue([
+    { username: 'active1', lastActive: new Date() },
+    { username: 'active2', lastActive: new Date() }
   ])
 }));
 
-jest.mock('../../../server/models/Item', () => ({
+jest.mock('../../../server/models/ScrapyardItem', () => ({
   findRecent: jest.fn().mockResolvedValue([
     { id: 1, title: 'Test Item 1' },
     { id: 2, title: 'Test Item 2' }
@@ -20,7 +25,8 @@ jest.mock('../../../server/models/Item', () => ({
   findFeatured: jest.fn().mockResolvedValue([
     { id: 3, title: 'Featured Item 1' },
     { id: 4, title: 'Featured Item 2' }
-  ])
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2)
 }));
 
 // Mock express-handlebars

--- a/tests/server/routes/users-auth.test.js
+++ b/tests/server/routes/users-auth.test.js
@@ -1,0 +1,96 @@
+const request = require('supertest');
+const express = require('express');
+const session = require('express-session');
+const passport = require('passport');
+const bcrypt = require('bcrypt');
+
+// Mock User model methods used in the routes and passport strategy
+jest.mock('../../../server/models/User', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  findOneWithPassword: jest.fn(),
+  findById: jest.fn()
+}));
+
+const User = require('../../../server/models/User');
+
+// Import passport config after mocking User
+const configurePassport = require('../../../server/utils/passport-config');
+
+// Helper to create an app with session and passport
+function createTestApp() {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+  app.use((req, res, next) => { req.flash = jest.fn(); next(); });
+  app.use(
+    session({
+      secret: 'test',
+      resave: false,
+      saveUninitialized: false,
+      name: 'wirebase.sid'
+    })
+  );
+  configurePassport(passport);
+  app.use(passport.initialize());
+  app.use(passport.session());
+  // mount routes
+  const usersRouter = require('../../../server/routes/users');
+  app.use('/users', usersRouter);
+  // protected route to verify session
+  app.get('/protected', (req, res) => {
+    if (req.isAuthenticated()) {
+      res.json({ id: req.user.id, username: req.user.username });
+    } else {
+      res.status(401).send('Unauthorized');
+    }
+  });
+  return app;
+}
+
+describe('User registration and login', () => {
+  const app = createTestApp();
+  const agent = request.agent(app);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers a new user', async () => {
+    User.findOne.mockResolvedValue(null);
+    User.create.mockResolvedValue({ id: '1', username: 'testuser', email: 'test@example.com' });
+
+    const res = await agent
+      .post('/users/register')
+      .send({
+        username: 'testuser',
+        email: 'test@example.com',
+        password: 'secret',
+        password2: 'secret'
+      });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/users/login');
+    expect(User.create).toHaveBeenCalled();
+  });
+
+  it('logs in an existing user and creates session', async () => {
+    const hashed = bcrypt.hashSync('secret', 10);
+    const user = { id: '1', username: 'testuser', email: 'test@example.com', password: hashed };
+    User.findOneWithPassword.mockResolvedValue(user);
+    User.findById.mockResolvedValue({ id: '1', username: 'testuser', email: 'test@example.com' });
+
+    const res = await agent
+      .post('/users/login')
+      .send({ email: 'test@example.com', password: 'secret' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/profile');
+    // session cookie should be set
+    expect(res.headers['set-cookie']).toEqual(expect.arrayContaining([expect.stringContaining('wirebase.sid')]));
+
+    const followUp = await agent.get('/protected');
+    expect(followUp.status).toBe(200);
+    expect(followUp.body.username).toBe('testuser');
+  });
+});

--- a/tests/wir-transactions.test.js
+++ b/tests/wir-transactions.test.js
@@ -3,9 +3,17 @@
  * Tests for the WIR currency system and transactions
  */
 
-const { supabase } = require('../server/utils/database');
-const WIRTransaction = require('../server/models/WIRTransaction');
-const createWIRTransactionsTable = require('../scripts/migrations/create-wir-transactions-table');
+if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY || !process.env.SUPABASE_SERVICE_KEY) {
+  // Skip the suite if Supabase credentials are not available
+  describe.skip('WIR Transactions', () => {
+    it('skipped because Supabase credentials are missing', () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  const { supabase } = require('../server/utils/database');
+  const WIRTransaction = require('../server/models/WIRTransaction');
+  const createWIRTransactionsTable = require('../scripts/migrations/create-wir-transactions-table');
 
 describe('WIR Transactions', () => {
   // Test user IDs
@@ -180,3 +188,4 @@ describe('WIR Transactions', () => {
     });
   });
 });
+}


### PR DESCRIPTION
## Summary
- fix index route tests to use existing models
- skip WIR transaction tests if Supabase credentials are missing
- add registration and login tests using supertest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450db21e04832fadd63b6922898080

## Summary by Sourcery

Add user authentication integration tests and refine existing route and transaction test suites.

New Features:
- Add registration and login tests for user authentication using supertest

Tests:
- Skip WIR transaction tests when Supabase credentials are unavailable
- Update index route tests to use existing models and include document counts