### PR TITLE
Add CSRF protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "compression": "^1.7.4",
     "connect-session-knex": "^3.0.1",
     "connect-timeout": "^1.9.0",
+    "csurf": "^1.11.0",
     "dompurify": "^3.0.8",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/server/views/forum/new-thread.handlebars
+++ b/server/views/forum/new-thread.handlebars
@@ -66,6 +66,7 @@
       {{/if}}
 
       <form action="/forum/new" method="POST" id="new-thread-form">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <div class="form-group">
           <label for="title">Thread Title</label>
           <input type="text" id="title" name="title" class="cyber-input" value="{{formData.title}}" required maxlength="100">

--- a/server/views/forum/thread.handlebars
+++ b/server/views/forum/thread.handlebars
@@ -145,6 +145,7 @@
         </div>
         <div class="cyber-window-content">
           <form action="/forum/thread/{{threadId}}/reply" method="POST">
+            <input type="hidden" name="_csrf" value="{{csrfToken}}">
             <!-- WYSIWYG Editor -->
             <div class="wysiwyg-editor">
               <div class="wysiwyg-toolbar">

--- a/server/views/scrapyard/submit.handlebars
+++ b/server/views/scrapyard/submit.handlebars
@@ -4,6 +4,7 @@
         <p class="cyber-text">Share your digital artifacts with the network.</p>
 
         <form action="/scrapyard/submit" method="POST" enctype="multipart/form-data" class="cyber-form">
+            <input type="hidden" name="_csrf" value="{{csrfToken}}">
             <div class="form-group">
                 <label for="title" class="cyber-label">Title *</label>
                 <input type="text" id="title" name="title" class="cyber-input" required maxlength="100">

--- a/server/views/scrapyard/view.handlebars
+++ b/server/views/scrapyard/view.handlebars
@@ -196,6 +196,7 @@
             <div class="modal-footer">
                 <button id="cancel-delete" class="cyber-button">Cancel</button>
                 <form action="/scrapyard/delete/{{item._id}}?_method=DELETE" method="POST">
+                    <input type="hidden" name="_csrf" value="{{csrfToken}}">
                     <button type="submit" class="cyber-button danger">Delete</button>
                 </form>
             </div>

--- a/server/views/users/login.handlebars
+++ b/server/views/users/login.handlebars
@@ -41,6 +41,7 @@
                 {{/if}}
 
                 <form action="/users/login" method="POST" class="login-form">
+                    <input type="hidden" name="_csrf" value="{{csrfToken}}">
                     <div class="form-group">
                         <label for="email">Email Address</label>
                         <input type="email" id="email" name="email" class="cyber-input" value="{{email}}" required>

--- a/server/views/users/register.handlebars
+++ b/server/views/users/register.handlebars
@@ -44,6 +44,7 @@
                 {{/if}}
 
                 <form action="/users/register" method="POST" class="register-form">
+                    <input type="hidden" name="_csrf" value="{{csrfToken}}">
                     <div class="form-group">
                         <label for="username">Username</label>
                         <input type="text" id="username" name="username" class="cyber-input" value="{{username}}" required>


### PR DESCRIPTION
## Summary
- install `csurf`
- enable CSRF middleware in the Express app
- handle CSRF errors globally
- include hidden CSRF fields in login, register, scrapyard and forum forms

## Testing
- `npm test` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450da311f0832f8b60dd37c72cd96c

## Summary by Sourcery

Add CSRF protection to prevent cross-site request forgery by integrating csurf middleware, injecting CSRF tokens into forms, handling CSRF errors, and skipping the middleware in test mode.

New Features:
- Integrate CSRF protection using csurf middleware in the Express server
- Embed hidden CSRF token fields in login, registration, forum, and scrapyard forms

Enhancements:
- Add a global CSRF error handler to render a custom invalid token response

Build:
- Add csurf to project dependencies

Chores:
- Disable CSRF protection in test environment to avoid interference with automated tests