### PR TITLE
Add centralized error middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -305,6 +305,7 @@ const dbMonitor = require('./server/utils/db-monitor');
 const dbHealth = require('./server/utils/db-health');
 const dbErrorHandler = require('./server/utils/db-error-handler');
 const dbLeakDetector = require('./server/utils/db-leak-detector');
+const errorHandler = require('./server/middleware/error-handler');
 const { queryTimeoutMiddleware, transactionTimeoutMiddleware } = require('./server/middleware/query-timeout');
 
 // Initialize database utilities with knex instance
@@ -351,24 +352,7 @@ app.use((req, res) => {
 });
 
 // Error handler
-app.use((err, req, res, next) => {
-  console.error('Server Error:', err.name, err.message);
-  console.error('Error Stack:', err.stack);
-  console.error('Request URL:', req.method, req.url);
-  console.error('Request Headers:', JSON.stringify(req.headers, null, 2));
-
-  // Check if headers have already been sent
-  if (res.headersSent) {
-    return next(err);
-  }
-
-  res.status(500).render('error', {
-    title: '500 - Server Error',
-    errorCode: 500,
-    message: 'Something went wrong on our end.',
-    theme: 'broken-window'
-  });
-});
+app.use(errorHandler);
 
 // Handle unhandled promise rejections
 process.on('unhandledRejection', (reason, promise) => {

--- a/server/middleware/error-handler.js
+++ b/server/middleware/error-handler.js
@@ -1,0 +1,22 @@
+// Custom error-handling middleware
+module.exports = (err, req, res, next) => {
+  console.error('Server Error:', err);
+
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const status = err.status || 500;
+  const message = err.message || 'Something went wrong on our end.';
+
+  if (req.accepts('json') && !req.accepts('html')) {
+    return res.status(status).json({ error: message });
+  }
+
+  res.status(status).render('error', {
+    title: `${status} - ${status === 404 ? 'Not Found' : 'Server Error'}`,
+    errorCode: status,
+    message,
+    theme: status === 500 ? 'broken-window' : 'dark-dungeon'
+  });
+};

--- a/server/routes/feed.js
+++ b/server/routes/feed.js
@@ -5,7 +5,7 @@ const User = require('../models/User');
 const ScrapyardItem = require('../models/ScrapyardItem');
 
 // Global site feed
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
   try {
     // Create main site feed
     const feed = new Feed({
@@ -95,12 +95,12 @@ router.get('/', async (req, res) => {
     }
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error generating feed');
+    next(err);
   }
 });
 
 // User-specific feed
-router.get('/user/:username', async (req, res) => {
+router.get('/user/:username', async (req, res, next) => {
   try {
     // Find user
     const user = await User.findOne({ username: req.params.username });
@@ -166,12 +166,12 @@ router.get('/user/:username', async (req, res) => {
     }
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error generating feed');
+    next(err);
   }
 });
 
 // Category-specific feed for Scrapyard
-router.get('/scrapyard/:category', async (req, res) => {
+router.get('/scrapyard/:category', async (req, res, next) => {
   try {
     const category = req.params.category;
     const validCategories = ['widget', 'template', 'icon', 'banner', 'gif', 'all'];
@@ -251,7 +251,7 @@ router.get('/scrapyard/:category', async (req, res) => {
     }
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error generating feed');
+    next(err);
   }
 });
 

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -14,7 +14,7 @@ const ensureAuthenticated = (req, res, next) => {
 };
 
 // User's own profile page
-router.get('/', ensureAuthenticated, async (req, res) => {
+router.get('/', ensureAuthenticated, async (req, res, next) => {
   try {
     // Find the user with their streetpass visitors populated
     const user = await User.findById(req.user._id)
@@ -43,17 +43,12 @@ router.get('/', ensureAuthenticated, async (req, res) => {
     });
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'There was an error loading your profile',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
 // View another user's profile
-router.get('/:username', async (req, res) => {
+router.get('/:username', async (req, res, next) => {
   try {
     // Find the user by username
     const profileUser = await User.findOne({ username: req.params.username });
@@ -125,12 +120,7 @@ router.get('/:username', async (req, res) => {
     });
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'There was an error loading this profile',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
@@ -144,7 +134,7 @@ router.get('/edit/html', ensureAuthenticated, (req, res) => {
 });
 
 // Save profile HTML
-router.post('/edit/html', ensureAuthenticated, async (req, res) => {
+router.post('/edit/html', ensureAuthenticated, async (req, res, next) => {
   try {
     const { profileHtml } = req.body;
     
@@ -157,12 +147,7 @@ router.post('/edit/html', ensureAuthenticated, async (req, res) => {
     res.redirect('/profile');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'There was an error saving your profile HTML',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
@@ -176,7 +161,7 @@ router.get('/edit/css', ensureAuthenticated, (req, res) => {
 });
 
 // Save profile CSS
-router.post('/edit/css', ensureAuthenticated, async (req, res) => {
+router.post('/edit/css', ensureAuthenticated, async (req, res, next) => {
   try {
     const { profileCss } = req.body;
     
@@ -189,12 +174,7 @@ router.post('/edit/css', ensureAuthenticated, async (req, res) => {
     res.redirect('/profile');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'There was an error saving your profile CSS',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
@@ -208,7 +188,7 @@ router.get('/terminal', ensureAuthenticated, (req, res) => {
 });
 
 // RSS feed for user profile
-router.get('/:username/feed', async (req, res) => {
+router.get('/:username/feed', async (req, res, next) => {
   try {
     // Find the user by username
     const user = await User.findOne({ username: req.params.username });
@@ -263,12 +243,12 @@ router.get('/:username/feed', async (req, res) => {
     res.send(feed.rss2());
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error generating feed');
+    next(err);
   }
 });
 
 // Update streetpass emote
-router.post('/:username/streetpass/emote', ensureAuthenticated, async (req, res) => {
+router.post('/:username/streetpass/emote', ensureAuthenticated, async (req, res, next) => {
   try {
     const { emote } = req.body;
     const profileUser = await User.findOne({ username: req.params.username });
@@ -291,7 +271,7 @@ router.post('/:username/streetpass/emote', ensureAuthenticated, async (req, res)
     }
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    next(err);
   }
 });
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -36,7 +36,7 @@ router.get('/register', (req, res) => {
 });
 
 // Handle user registration
-router.post('/register', async (req, res) => {
+router.post('/register', async (req, res, next) => {
   const { username, email, password, password2, displayName, customGlyph, statusMessage } = req.body;
   const errors = [];
 
@@ -124,12 +124,7 @@ router.post('/register', async (req, res) => {
     res.redirect('/users/login');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'Registration error occurred',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
@@ -160,7 +155,7 @@ router.get('/forgot-password', (req, res) => {
 });
 
 // Handle password reset request
-router.post('/forgot-password', async (req, res) => {
+router.post('/forgot-password', async (req, res, next) => {
   const { email } = req.body;
   
   try {
@@ -171,12 +166,7 @@ router.post('/forgot-password', async (req, res) => {
     res.redirect('/users/login');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'Error processing password reset',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
@@ -190,7 +180,7 @@ router.get('/settings', ensureAuthenticated, (req, res) => {
 });
 
 // Update account settings
-router.post('/settings', ensureAuthenticated, async (req, res) => {
+router.post('/settings', ensureAuthenticated, async (req, res, next) => {
   const { displayName, email, statusMessage, customGlyph } = req.body;
   
   try {
@@ -212,17 +202,12 @@ router.post('/settings', ensureAuthenticated, async (req, res) => {
     res.redirect('/users/settings');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'Error updating account settings',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 
 // Change password
-router.post('/change-password', ensureAuthenticated, async (req, res) => {
+router.post('/change-password', ensureAuthenticated, async (req, res, next) => {
   const { currentPassword, newPassword, confirmPassword } = req.body;
   const errors = [];
   
@@ -269,12 +254,7 @@ router.post('/change-password', ensureAuthenticated, async (req, res) => {
     res.redirect('/users/settings');
   } catch (err) {
     console.error(err);
-    res.status(500).render('error', {
-      title: 'Server Error',
-      errorCode: 500,
-      message: 'Error updating password',
-      theme: 'broken-window'
-    });
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- create `server/middleware/error-handler.js`
- register middleware in `server.js`
- forward errors with `next(err)` in user, feed and profile routes

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item')*

------
https://chatgpt.com/codex/tasks/task_e_68450da14218832f8f256dc18a4468b3

## Summary by Sourcery

Introduce centralized error-handling middleware and refactor existing routes to forward errors to it.

Enhancements:
- Add `error-handler.js` and register it in `server.js` to handle errors globally.
- Refactor profile, users, and feed routes to call `next(err)` instead of rendering or sending error responses inline.