### PR TITLE
Implement feed caching and invalidation

### DIFF
--- a/server/models/ScrapyardItem.js
+++ b/server/models/ScrapyardItem.js
@@ -1,4 +1,5 @@
 const { supabase, supabaseAdmin } = require('../utils/database');
+const { clearCache } = require('../utils/performance');
 
 /**
  * ScrapyardItem model for Supabase
@@ -45,8 +46,9 @@ class ScrapyardItem {
         throw error;
       }
 
-      // Convert back to camelCase for app use
-      return ScrapyardItem.formatItem(data);
+      const formatted = ScrapyardItem.formatItem(data);
+      clearCache(/^feed:/);
+      return formatted;
     } catch (error) {
       console.error('Error creating scrapyard item:', error);
       throw error;
@@ -258,7 +260,7 @@ class ScrapyardItem {
 
       // Update this instance with the returned data
       Object.assign(this, ScrapyardItem.formatItem(data));
-
+      clearCache(/^feed:/);
       return this;
     } catch (error) {
       console.error('Error saving scrapyard item:', error);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,5 +1,6 @@
 const { supabase, supabaseAdmin } = require('../utils/database');
 const bcrypt = require('bcrypt');
+const { clearCache } = require('../utils/performance');
 
 /**
  * User model for Supabase
@@ -223,7 +224,9 @@ class User {
         throw error;
       }
 
-      return User.formatUser(data);
+      const formatted = User.formatUser(data);
+      clearCache(/^feed:/);
+      return formatted;
     } catch (error) {
       console.error('Error updating user:', error);
       throw error;
@@ -278,7 +281,7 @@ class User {
 
       // Update this instance with the returned data
       Object.assign(this, User.formatUser(data));
-
+      clearCache(/^feed:/);
       return this;
     } catch (error) {
       console.error('Error saving user:', error);


### PR DESCRIPTION
## Summary
- implement cached responses for feed routes
- invalidate feed cache on item creation/updates
- invalidate feed cache on user profile updates

## Testing
- `npm run lint`
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450d9f2ad8832fafc5f2e08e42d681

## Summary by Sourcery

Add a caching layer to feed endpoints to improve performance and automatically clear stale feed data when items or user profiles are updated.

Enhancements:
- Cache global, user, and scrapyard feed responses per format with a 5-minute TTL and X-Cache headers
- Invalidate feed caches on ScrapyardItem creation or updates and on User profile changes
- Extract common helpers to determine feed content types and format feed output uniformly