### PR TITLE
Replace query with execute_sql RPC

### DIFF
--- a/scripts/migrations/create-forum-tables.js
+++ b/scripts/migrations/create-forum-tables.js
@@ -18,7 +18,7 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_threads table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE forum_threads (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           title TEXT NOT NULL,
@@ -38,7 +38,7 @@ async function createForumTables() {
         CREATE INDEX idx_forum_threads_creator_id ON forum_threads(creator_id);
         CREATE INDEX idx_forum_threads_created_at ON forum_threads(created_at);
         CREATE INDEX idx_forum_threads_updated_at ON forum_threads(updated_at);
-      `);
+      ` });
       
       console.log('forum_threads table created successfully!');
     } else {
@@ -55,7 +55,7 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_replies table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE forum_replies (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           thread_id UUID NOT NULL REFERENCES forum_threads(id) ON DELETE CASCADE,
@@ -69,7 +69,7 @@ async function createForumTables() {
         CREATE INDEX idx_forum_replies_thread_id ON forum_replies(thread_id);
         CREATE INDEX idx_forum_replies_creator_id ON forum_replies(creator_id);
         CREATE INDEX idx_forum_replies_created_at ON forum_replies(created_at);
-      `);
+      ` });
       
       console.log('forum_replies table created successfully!');
     } else {
@@ -86,7 +86,7 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_categories table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE forum_categories (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           name TEXT NOT NULL UNIQUE,
@@ -96,10 +96,10 @@ async function createForumTables() {
           created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
           updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
         );
-        
+
         -- Create index
         CREATE INDEX idx_forum_categories_display_order ON forum_categories(display_order);
-      `);
+      ` });
       
       // Insert default categories
       await supabaseAdmin.from('forum_categories').insert([

--- a/scripts/migrations/create-streetpass-table.js
+++ b/scripts/migrations/create-streetpass-table.js
@@ -18,7 +18,7 @@ async function createStreetpassTable() {
       // Table doesn't exist, create it
       console.log('Creating streetpass_visits table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE streetpass_visits (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           visitor_id UUID NOT NULL REFERENCES users(id),
@@ -35,7 +35,7 @@ async function createStreetpassTable() {
         CREATE INDEX idx_streetpass_visits_profile_id ON streetpass_visits(profile_id);
         CREATE INDEX idx_streetpass_visits_visitor_id ON streetpass_visits(visitor_id);
         CREATE INDEX idx_streetpass_visits_visited_at ON streetpass_visits(visited_at);
-      `);
+      ` });
       
       console.log('streetpass_visits table created successfully!');
     } else {

--- a/scripts/migrations/create-wir-transactions-table.js
+++ b/scripts/migrations/create-wir-transactions-table.js
@@ -18,7 +18,7 @@ async function createWIRTransactionsTable() {
       // Table doesn't exist, create it
       console.log('Creating market_wir_transactions table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE market_wir_transactions (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -48,7 +48,7 @@ async function createWIRTransactionsTable() {
         CREATE INDEX idx_wir_transactions_reference_id ON market_wir_transactions(reference_id);
         CREATE INDEX idx_wir_transactions_created_at ON market_wir_transactions(created_at);
         CREATE INDEX idx_wir_transactions_type ON market_wir_transactions(transaction_type);
-      `);
+      ` });
       
       console.log('market_wir_transactions table created successfully!');
     } else {

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -80,7 +80,7 @@ async function initializeDatabase() {
 
     if (error && error.code === '42P01') { // Table doesn't exist
       console.log('Creating users table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE users (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           username TEXT UNIQUE NOT NULL,
@@ -111,7 +111,7 @@ async function initializeDatabase() {
         -- Create index on username and email
         CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
         CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-      `);
+      ` });
     }
 
     // Create scrapyard_items table if not exists
@@ -122,7 +122,7 @@ async function initializeDatabase() {
 
     if (itemsError && itemsError.code === '42P01') { // Table doesn't exist
       console.log('Creating scrapyard_items table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE scrapyard_items (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           title TEXT NOT NULL,
@@ -146,7 +146,7 @@ async function initializeDatabase() {
         -- Create indexes
         CREATE INDEX IF NOT EXISTS idx_scrapyard_items_creator ON scrapyard_items(creator);
         CREATE INDEX IF NOT EXISTS idx_scrapyard_items_category ON scrapyard_items(category);
-      `);
+      ` });
     }
 
     // Create sessions table if not exists
@@ -157,7 +157,7 @@ async function initializeDatabase() {
 
     if (sessionsError && sessionsError.code === '42P01') { // Table doesn't exist
       console.log('Creating sessions table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', { sql: `
         CREATE TABLE sessions (
           sid varchar NOT NULL PRIMARY KEY,
           sess json NOT NULL,
@@ -165,7 +165,7 @@ async function initializeDatabase() {
         );
 
         CREATE INDEX IF NOT EXISTS idx_sessions_expired ON sessions(expired);
-      `);
+      ` });
     }
 
     console.log('Database initialization complete');


### PR DESCRIPTION
## Summary
- use `supabaseAdmin.rpc('execute_sql')` wherever raw SQL was executed
- update migration scripts accordingly

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_684501d6dcb0832f91dded7f83105c23

## Summary by Sourcery

Enhancements:
- Replace all supabaseAdmin.query calls with supabaseAdmin.rpc('execute_sql') in migration and initialization scripts