### PR TITLE
Refactor profile routes to use Streetpass model

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -2,7 +2,9 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/User');
 const ScrapyardItem = require('../models/ScrapyardItem');
+const Streetpass = require('../models/Streetpass');
 const Feed = require('feed').Feed;
+const { supabase } = require('../utils/database');
 
 // Middleware to ensure user is authenticated
 const ensureAuthenticated = (req, res, next) => {
@@ -16,17 +18,11 @@ const ensureAuthenticated = (req, res, next) => {
 // User's own profile page
 router.get('/', ensureAuthenticated, async (req, res) => {
   try {
-    // Find the user with their streetpass visitors populated
-    const user = await User.findById(req.user._id)
-      .populate({
-        path: 'streetpassVisitors.user',
-        select: 'username customGlyph avatar'
-      });
-    
-    // Get recent visitors
-    const visitors = user.streetpassVisitors
-      .sort((a, b) => b.timestamp - a.timestamp)
-      .slice(0, 10);
+    // Find the user
+    const user = await User.findById(req.user.id);
+
+    // Get recent visitors using Streetpass model
+    const visitors = await Streetpass.getVisitors(user.id, 10);
     
     // User's items in the Scrapyard
     const userItems = await ScrapyardItem.find({ creator: user._id })
@@ -68,26 +64,11 @@ router.get('/:username', async (req, res) => {
     }
     
     // Check if the current user is the owner
-    const isOwner = req.isAuthenticated() && req.user._id.toString() === profileUser._id.toString();
+    const isOwner = req.isAuthenticated() && req.user.id === profileUser.id;
     
     // Record a visit if authenticated and not the profile owner
-    if (req.isAuthenticated() && !isOwner) {
-      // Check if there's already a recent visit (within 1 hour)
-      const recentVisit = profileUser.streetpassVisitors.find(v => 
-        v.user.toString() === req.user._id.toString() && 
-        ((new Date()) - v.timestamp) < 60 * 60 * 1000
-      );
-      
-      if (!recentVisit && profileUser.streetpassEnabled) {
-        // Add current user to profile's visitors
-        profileUser.streetpassVisitors.push({
-          user: req.user._id,
-          timestamp: new Date(),
-          emote: '👋' // Default emote
-        });
-        
-        await profileUser.save();
-      }
+    if (req.isAuthenticated() && !isOwner && profileUser.streetpassEnabled) {
+      await Streetpass.recordVisit(req.user.id, profileUser.id, '👋');
     }
     
     // Get user's items in the Scrapyard
@@ -99,21 +80,8 @@ router.get('/:username', async (req, res) => {
         return []; // Return empty array instead of failing
       });
     
-    // Populate streetpass visitors with error handling
-    try {
-      await profileUser.populate({
-        path: 'streetpassVisitors.user',
-        select: 'username customGlyph avatar'
-      });
-    } catch (err) {
-      console.error('Failed to populate visitors:', err);
-      profileUser.streetpassVisitors = [];
-    }
-    
-    // Get recent visitors
-    const visitors = profileUser.streetpassVisitors
-      .sort((a, b) => b.timestamp - a.timestamp)
-      .slice(0, 10);
+    // Get recent visitors via Streetpass model
+    const visitors = await Streetpass.getVisitors(profileUser.id, 10);
     
     res.render('profile/view', {
       title: `${profileUser.displayName} - Wirebase Profile`,
@@ -149,9 +117,7 @@ router.post('/edit/html', ensureAuthenticated, async (req, res) => {
     const { profileHtml } = req.body;
     
     // Update the user's profile HTML
-    const user = await User.findById(req.user._id);
-    user.profileHtml = profileHtml;
-    await user.save();
+    await User.findByIdAndUpdate(req.user.id, { profileHtml });
     
     req.flash('success_msg', 'Profile HTML updated successfully');
     res.redirect('/profile');
@@ -181,9 +147,7 @@ router.post('/edit/css', ensureAuthenticated, async (req, res) => {
     const { profileCss } = req.body;
     
     // Update the user's profile CSS
-    const user = await User.findById(req.user._id);
-    user.profileCss = profileCss;
-    await user.save();
+    await User.findByIdAndUpdate(req.user.id, { profileCss });
     
     req.flash('success_msg', 'Profile CSS updated successfully');
     res.redirect('/profile');
@@ -277,14 +241,18 @@ router.post('/:username/streetpass/emote', ensureAuthenticated, async (req, res)
       return res.status(404).json({ error: 'User not found' });
     }
     
-    // Find the visitor entry and update the emote
-    const visitorIndex = profileUser.streetpassVisitors.findIndex(
-      v => v.user.toString() === req.user._id.toString()
-    );
-    
-    if (visitorIndex !== -1) {
-      profileUser.streetpassVisitors[visitorIndex].emote = emote;
-      await profileUser.save();
+    // Find the visit record and update the emote using Supabase
+    const { data: visit, error } = await supabase
+      .from('streetpass_visits')
+      .select('id')
+      .eq('visitor_id', req.user.id)
+      .eq('profile_id', profileUser.id)
+      .single();
+
+    if (error && error.code !== 'PGRST116') throw error;
+
+    if (visit) {
+      await Streetpass.updateEmote(visit.id, emote);
       return res.json({ success: true });
     } else {
       return res.status(400).json({ error: 'No visit found' });


### PR DESCRIPTION
## Summary
- query user visitors through Streetpass model
- update profile routes to use `findById` and `findByIdAndUpdate`
- refactor emote updates to call Supabase directly

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item' and fetch errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684501de1eec832fb203c984827f5121