### PR TITLE
Fix knex reset in DB maintenance

### DIFF
--- a/server/utils/db-health.js
+++ b/server/utils/db-health.js
@@ -126,16 +126,20 @@ const performMaintenance = async (knex = null) => {
 
       // Destroy and recreate the pool
       await kInstance.destroy();
-      await kInstance.initialize();
+
+      // Recreate knex instance using original configuration
+      const newKnex = require('knex')(kInstance.client.config);
+      knexInstance = newKnex;
+      global.knex = newKnex;
 
       // Reset health check status
       healthCheckStatus.consecutiveFailures = 0;
       dbMonitor.resetMetrics();
-      dbMonitor.setupPoolMonitoring(kInstance);
+      dbMonitor.setupPoolMonitoring(newKnex);
     }
 
     // Get pool status after maintenance
-    const afterStatus = dbMonitor.getPoolStatus(kInstance);
+    const afterStatus = dbMonitor.getPoolStatus(knexInstance);
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
- recreate the knex instance after destroying the pool in `db-health`
- update references to use the new instance

## Testing
- `npm test` *(fails: Missing required Supabase environment variables and module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684501d2048c832f8ac2a6f0ac91e03b

## Summary by Sourcery

Fix DB maintenance by tearing down and rebuilding the Knex connection pool with a new instance and ensuring all references are updated

Bug Fixes:
- Properly recreate the Knex instance after destroying the pool during DB maintenance

Enhancements:
- Update all pool monitoring and status checks to use the newly created Knex instance instead of the old one