### PR TITLE
Add toast notifications for vivid market

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "eslint": "^8.38.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "nodemon": "^2.0.22",
     "supertest": "^6.3.3"
   },

--- a/public/css/vivid-market.css
+++ b/public/css/vivid-market.css
@@ -691,15 +691,22 @@
 }
 
 /* Notification */
-.notification {
+.toast-container {
   position: fixed;
   bottom: 20px;
   right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 1000;
+}
+.notification {
+  position: relative;
   padding: 15px 20px;
   background-color: var(--bg-medium);
   border-left: 4px solid var(--primary-color);
   color: var(--text-light);
-  z-index: 1000;
+  z-index: 1;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   transform: translateX(120%);
   transition: transform 0.3s ease;
@@ -1167,14 +1174,12 @@
 
 /* Notification */
 .notification {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
+  position: relative;
   padding: 15px 20px;
   border-radius: 4px;
   color: #fff;
   font-size: 0.9rem;
-  z-index: 1000;
+  z-index: 1;
   transform: translateY(100px);
   opacity: 0;
   transition: all 0.3s ease;

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -1,9 +1,21 @@
 /**
- * Placeholder function for initializing notifications.
- * TODO: Implement actual notification initialization logic.
+ * Setup the notification system for the market.
+ * Creates a toast container used by showNotification.
  */
 function initializeNotifications() {
-  console.warn('initializeNotifications function called, but not implemented.');
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container';
+    container.style.position = 'fixed';
+    container.style.bottom = '20px';
+    container.style.right = '20px';
+    container.style.zIndex = '1000';
+    container.style.display = 'flex';
+    container.style.flexDirection = 'column';
+    container.style.gap = '10px';
+    document.body.appendChild(container);
+  }
 }
 /**
  * Vivid Market JavaScript
@@ -217,26 +229,29 @@ function initializeItemPreviews() {
  * @param {string} type - Notification type (success, error, info)
  */
 function showNotification(message, type = 'info') {
-  // Create notification element if it doesn't exist
-  let notification = document.querySelector('.notification');
-  if (!notification) {
-    notification = document.createElement('div');
-    notification.className = 'notification';
-    document.body.appendChild(notification);
+  // Ensure notification system is initialized
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    initializeNotifications();
+    container = document.querySelector('.toast-container');
   }
 
-  // Set notification content and type
-  notification.textContent = message;
+  const notification = document.createElement('div');
   notification.className = `notification ${type}`;
+  notification.textContent = message;
+  container.appendChild(notification);
 
   // Show notification
-  setTimeout(() => {
+  requestAnimationFrame(() => {
     notification.classList.add('show');
-  }, 10);
+  });
 
-  // Hide notification after 3 seconds
+  // Hide and remove notification after 3 seconds
   setTimeout(() => {
     notification.classList.remove('show');
+    const removeFn = () => notification.remove();
+    notification.addEventListener('transitionend', removeFn, { once: true });
+    setTimeout(removeFn, 300); // fallback if transition event doesn't fire
   }, 3000);
 }
 

--- a/tests/vivid-market-notifications.test.js
+++ b/tests/vivid-market-notifications.test.js
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('vivid-market notifications', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.resetModules();
+  });
+
+  const loadScript = () => {
+    const fs = require('fs');
+    const path = require('path');
+    const script = fs.readFileSync(path.join(__dirname, '../public/js/vivid-market.js'), 'utf8');
+    window.eval(script);
+  };
+
+  test('initializeNotifications creates container', () => {
+    loadScript();
+    window.initializeNotifications();
+    const container = document.querySelector('.toast-container');
+    expect(container).not.toBeNull();
+  });
+
+  test('showNotification adds and removes toast', () => {
+    jest.useFakeTimers();
+    loadScript();
+    window.initializeNotifications();
+
+    window.showNotification('Hello', 'success');
+    let toast = document.querySelector('.toast-container .notification');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe('Hello');
+
+    // Fast-forward time
+    jest.runAllTimers();
+
+    toast = document.querySelector('.toast-container .notification');
+    expect(toast).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `initializeNotifications` to create a toast container
- make `showNotification` use the container and auto-remove messages
- style `.toast-container` and adjust `.notification` rules
- add tests for notification setup
- install `jest-environment-jsdom`

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item' from 'tests/server/routes/index.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_684501bb8780832fbb488328840a7e38