### PR TITLE
Fix clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can use these accounts to explore the platform:
 
 1. Clone the repository
    ```
-   git clone https://github.com/yourusername/wirebase.git
+   git clone https://github.com/yourusername/wirebase-social.git
    cd wirebase
    ```
 


### PR DESCRIPTION
## Summary
- update `git clone` URL in README

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_684501ab4a58832f9b0fe403457857df