### PR TITLE
Improve SimpleCache expiration cleanup

### DIFF
--- a/server/utils/performance.js
+++ b/server/utils/performance.js
@@ -20,14 +20,28 @@ try {
   console.warn('NodeCache module not found, using fallback implementation');
   // Simple fallback implementation
   NodeCache = class SimpleCache {
-    constructor() {
+    constructor(options = {}) {
       this.cache = new Map();
+      this.stdTTL = options.stdTTL || 0;
+      this.checkperiod = options.checkperiod || 0;
+
+      if (this.checkperiod > 0) {
+        this.cleanupTimer = setInterval(() => {
+          const now = Date.now();
+          for (const [key, entry] of this.cache.entries()) {
+            if (entry.expires && now > entry.expires) {
+              this.cache.delete(key);
+            }
+          }
+        }, this.checkperiod * 1000);
+      }
     }
 
     set(key, value, ttl) {
+      const effectiveTtl = ttl !== undefined ? ttl : this.stdTTL;
       this.cache.set(key, {
         value,
-        expires: ttl ? Date.now() + (ttl * 1000) : null
+        expires: effectiveTtl ? Date.now() + (effectiveTtl * 1000) : null
       });
       return true;
     }
@@ -52,6 +66,13 @@ try {
 
     keys() {
       return Array.from(this.cache.keys());
+    }
+
+    close() {
+      if (this.cleanupTimer) {
+        clearInterval(this.cleanupTimer);
+        this.cleanupTimer = null;
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary
- make fallback SimpleCache accept options for TTL and check period
- use setInterval to periodically remove expired entries
- allow closing cleanup timer

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_684501a62508832fb0ce255bcb5f0b9a

## Summary by Sourcery

Extend the fallback SimpleCache to support configurable TTL defaults, periodic expiration cleanup, and timer shutdown.

New Features:
- Allow specifying default TTL and cleanup interval in SimpleCache constructor options
- Automatically purge expired cache entries at the configured check period
- Add a close() method to stop the periodic cleanup timer