### PR TITLE
Audit utilities for missing knex

### DIFF
--- a/server/utils/db-error-handler.js
+++ b/server/utils/db-error-handler.js
@@ -53,6 +53,12 @@ const handleError = async (error, context = 'unknown') => {
 
   // Get pool status - use stored knex instance or fallback to global
   const kInstance = knexInstance || global.knex;
+
+  if (!kInstance) {
+    console.warn('WARN: No knex instance available for error handling');
+    return error;
+  }
+
   const poolStatus = dbMonitor.getPoolStatus(kInstance);
 
   // Log error with context and pool status
@@ -82,6 +88,12 @@ const handleError = async (error, context = 'unknown') => {
  */
 const getErrorStats = (knex = null) => {
   const kInstance = knex || knexInstance || global.knex;
+
+  if (!kInstance) {
+    console.warn('WARN: No knex instance available for error statistics');
+    return { ...errorStats, poolStatus: null };
+  }
+
   return {
     ...errorStats,
     poolStatus: dbMonitor.getPoolStatus(kInstance)

--- a/server/utils/db-health.js
+++ b/server/utils/db-health.js
@@ -94,6 +94,12 @@ const checkHealth = async (knex = null) => {
  */
 const getHealthStatus = (knex = null) => {
   const kInstance = knex || knexInstance || global.knex;
+
+  if (!kInstance) {
+    console.warn('WARN: No knex instance available to get health status');
+    return { ...healthCheckStatus, poolStatus: null };
+  }
+
   return {
     ...healthCheckStatus,
     poolStatus: dbMonitor.getPoolStatus(kInstance)


### PR DESCRIPTION
## Summary
- add explicit warnings for missing knex in db health and error utils
- early return when knex instance is unavailable

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845019b3a3c832fa024c9b55d5f3f8a

## Summary by Sourcery

Enhancements:
- Emit a warning and return default values in health and error utilities if no knex instance is provided