### PR TITLE
Fix username regex check

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -60,7 +60,7 @@ router.post('/register', async (req, res) => {
     errors.push({ msg: 'Username must be between 3 and 20 characters' });
   }
 
-  if (username && !/^[a-zA-Z0-9_-]+$/.test(username)) {
+  if (username && !/^[a-zA-Z0-9_-]+$/u.test(username)) {
     errors.push({ msg: 'Username can only contain letters, numbers, underscores, and hyphens' });
   }
 


### PR DESCRIPTION
## Summary
- update username validation regex

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6845018c131c832f9218ee22a4cce1fa

## Summary by Sourcery

Bug Fixes:
- Add 'u' flag to username validation regex to correctly enforce allowed characters