### PR TITLE
Fix dotenv warning spam

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,11 +1,15 @@
 // Main server file for Wirebase
+let dotenvWarned = false;
 try {
   // Try to load dotenv if available
   const dotenv = require('dotenv');
   dotenv.config();
   console.log('Environment variables loaded from .env file');
 } catch (err) {
-  console.warn('dotenv module not found, using existing environment variables');
+  if (!dotenvWarned) {
+    console.warn('dotenv module not found, using existing environment variables');
+    dotenvWarned = true;
+  }
 }
 
 // Import performance optimization utilities


### PR DESCRIPTION
## Summary
- ensure dotenv warning only prints once on server init

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item')*

------
https://chatgpt.com/codex/tasks/task_e_6845016c5a68832fb2c58ec96379482f

## Summary by Sourcery

Enhancements:
- Add a flag to suppress repeated dotenv warning messages