### PR TITLE
Refactor query timeout middleware

### DIFF
--- a/server/middleware/query-timeout.js
+++ b/server/middleware/query-timeout.js
@@ -26,26 +26,29 @@ const queryTimeoutMiddleware = (knexInstance, timeout = 30000) => {
   console.log('knex.client:', knexInstance?.client ? 'defined' : 'undefined');
 
   return (req, res, next) => {
-    // Check if knex and knex.client are defined before accessing
-    if (!knexInstance || !knexInstance.client) {
-      console.error('ERROR: knex or knex.client is undefined in query timeout middleware execution');
+    if (!knexInstance || typeof knexInstance.raw !== 'function') {
+      console.error('ERROR: knex.raw is undefined in query timeout middleware execution');
       return next();
     }
 
-    // Store original query method
-    const originalQuery = knexInstance.client.query;
+    // Store original raw method
+    const originalRaw = knexInstance.raw.bind(knexInstance);
 
-    // Override query method with timeout
-    knexInstance.client.query = (...args) => {
-      // Create a promise that resolves with the query result
-      const queryPromise = originalQuery.apply(knexInstance.client, args);
+    // Override raw to add timeout race
+    knexInstance.raw = (...args) => {
+      const queryBuilder = originalRaw(...args);
 
-      // Create a promise that rejects after the timeout
+      // Apply knex level timeout when available for maximum compatibility
+      if (typeof queryBuilder.timeout === 'function') {
+        queryBuilder.timeout(timeout, { cancel: true });
+      }
+
+      const queryPromise = Promise.resolve(queryBuilder);
+
       const timeoutPromise = new Promise((_, reject) => {
         const id = setTimeout(() => {
           clearTimeout(id);
 
-          // Log pool status on timeout
           const poolStatus = dbMonitor.getPoolStatus(knexInstance);
           console.error('Query timeout detected', {
             query: args[0],
@@ -53,28 +56,21 @@ const queryTimeoutMiddleware = (knexInstance, timeout = 30000) => {
             poolStatus
           });
 
-          // Trigger health check on timeout
           dbHealth.checkHealth(knexInstance).catch(console.error);
 
           reject(new Error(`Query timeout after ${timeout}ms`));
         }, timeout);
 
-        // Clear timeout if query resolves or rejects
-        queryPromise
-          .then(() => clearTimeout(id))
-          .catch(() => clearTimeout(id));
+        queryPromise.finally(() => clearTimeout(id));
       });
 
-      // Race the query against the timeout
       return Promise.race([queryPromise, timeoutPromise]);
     };
 
-    // Continue to next middleware
     next();
 
-    // Restore original query method after request is complete
     res.on('finish', () => {
-      knexInstance.client.query = originalQuery;
+      knexInstance.raw = originalRaw;
     });
   };
 };


### PR DESCRIPTION
## Summary
- replace direct DB `client.query` override
- wrap `knex.raw` calls in a timeout race to detect long-running queries

## Testing
- `npm run lint`
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_684501459590832f9a685a4570221b05

## Summary by Sourcery

Refactor the query timeout middleware to wrap `knex.raw` calls in a timeout race instead of overriding `client.query`, leveraging built-in `queryBuilder.timeout` where available and simplifying cleanup.

Enhancements:
- Switch from overriding `knex.client.query` to wrapping `knex.raw` calls for timeouts
- Apply native `queryBuilder.timeout` cancellation when supported
- Simplify timeout cleanup by using `Promise.finally`
- Validate the existence of `knex.raw` rather than `knex.client` before applying middleware