### PR TITLE
Fix query patterns in api routes

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -16,9 +16,8 @@ const ensureAuthenticated = (req, res, next) => {
 // GET all users (public API)
 router.get('/users', async (req, res) => {
   try {
-    const users = await User.find()
-      .select('username displayName avatar customGlyph statusMessage')
-      .sort({ createdAt: -1 });
+    const users = await User.find({}, { sort: { createdAt: -1 } })
+      .select('username displayName avatar customGlyph statusMessage');
 
     res.json(users);
   } catch (err) {
@@ -30,8 +29,7 @@ router.get('/users', async (req, res) => {
 // GET user by username
 router.get('/users/:username', async (req, res) => {
   try {
-    const user = await User.findOne({ username: req.params.username })
-      .select('username displayName avatar customGlyph statusMessage createdAt');
+    const user = await User.findOne({ username: req.params.username });
 
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
@@ -68,8 +66,7 @@ router.get('/scrapyard', async (req, res) => {
 
     const items = await ScrapyardItem.find(query)
       .sort({ createdAt: -1 })
-      .limit(20)
-      .populate('creator', 'username displayName avatar customGlyph');
+      .limit(20);
 
     res.json(items);
   } catch (err) {
@@ -81,8 +78,7 @@ router.get('/scrapyard', async (req, res) => {
 // GET scrapyard item by ID
 router.get('/scrapyard/:id', async (req, res) => {
   try {
-    const item = await ScrapyardItem.findById(req.params.id)
-      .populate('creator', 'username displayName avatar customGlyph');
+    const item = await ScrapyardItem.findById(req.params.id);
 
     if (!item) {
       return res.status(404).json({ error: 'Item not found' });


### PR DESCRIPTION
## Summary
- update user queries in `/api` routes
- stop populating creator in scrapyard item routes

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item')*

------
https://chatgpt.com/codex/tasks/task_e_68450e6a59ec832f9c78707147fc01fe

## Summary by Sourcery

Refactor Mongoose queries in API routes to simplify sorting and field selection, and stop populating the creator on scrapyard item endpoints

Enhancements:
- Apply sort via query options when fetching all users instead of chaining .sort()
- Remove explicit .select() on user lookup by username to retrieve full user document
- Omit populating the creator field in scrapyard item list and detail endpoints