### PR TITLE
Refactor DB queries to RPC

### DIFF
--- a/scripts/migrations/create-forum-tables.js
+++ b/scripts/migrations/create-forum-tables.js
@@ -18,7 +18,8 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_threads table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE forum_threads (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           title TEXT NOT NULL,
@@ -38,7 +39,8 @@ async function createForumTables() {
         CREATE INDEX idx_forum_threads_creator_id ON forum_threads(creator_id);
         CREATE INDEX idx_forum_threads_created_at ON forum_threads(created_at);
         CREATE INDEX idx_forum_threads_updated_at ON forum_threads(updated_at);
-      `);
+      `
+      });
       
       console.log('forum_threads table created successfully!');
     } else {
@@ -55,7 +57,8 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_replies table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE forum_replies (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           thread_id UUID NOT NULL REFERENCES forum_threads(id) ON DELETE CASCADE,
@@ -69,7 +72,8 @@ async function createForumTables() {
         CREATE INDEX idx_forum_replies_thread_id ON forum_replies(thread_id);
         CREATE INDEX idx_forum_replies_creator_id ON forum_replies(creator_id);
         CREATE INDEX idx_forum_replies_created_at ON forum_replies(created_at);
-      `);
+      `
+      });
       
       console.log('forum_replies table created successfully!');
     } else {
@@ -86,7 +90,8 @@ async function createForumTables() {
       // Table doesn't exist, create it
       console.log('Creating forum_categories table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE forum_categories (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           name TEXT NOT NULL UNIQUE,
@@ -99,7 +104,8 @@ async function createForumTables() {
         
         -- Create index
         CREATE INDEX idx_forum_categories_display_order ON forum_categories(display_order);
-      `);
+      `
+      });
       
       // Insert default categories
       await supabaseAdmin.from('forum_categories').insert([

--- a/scripts/migrations/create-streetpass-table.js
+++ b/scripts/migrations/create-streetpass-table.js
@@ -18,7 +18,8 @@ async function createStreetpassTable() {
       // Table doesn't exist, create it
       console.log('Creating streetpass_visits table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE streetpass_visits (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           visitor_id UUID NOT NULL REFERENCES users(id),
@@ -35,7 +36,8 @@ async function createStreetpassTable() {
         CREATE INDEX idx_streetpass_visits_profile_id ON streetpass_visits(profile_id);
         CREATE INDEX idx_streetpass_visits_visitor_id ON streetpass_visits(visitor_id);
         CREATE INDEX idx_streetpass_visits_visited_at ON streetpass_visits(visited_at);
-      `);
+      `
+      });
       
       console.log('streetpass_visits table created successfully!');
     } else {

--- a/scripts/migrations/create-wir-transactions-table.js
+++ b/scripts/migrations/create-wir-transactions-table.js
@@ -18,7 +18,8 @@ async function createWIRTransactionsTable() {
       // Table doesn't exist, create it
       console.log('Creating market_wir_transactions table...');
       
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE market_wir_transactions (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -48,7 +49,8 @@ async function createWIRTransactionsTable() {
         CREATE INDEX idx_wir_transactions_reference_id ON market_wir_transactions(reference_id);
         CREATE INDEX idx_wir_transactions_created_at ON market_wir_transactions(created_at);
         CREATE INDEX idx_wir_transactions_type ON market_wir_transactions(transaction_type);
-      `);
+      `
+      });
       
       console.log('market_wir_transactions table created successfully!');
     } else {

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -1,0 +1,1 @@
+module.exports = require('./ScrapyardItem');

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -80,7 +80,8 @@ async function initializeDatabase() {
 
     if (error && error.code === '42P01') { // Table doesn't exist
       console.log('Creating users table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE users (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           username TEXT UNIQUE NOT NULL,
@@ -111,7 +112,8 @@ async function initializeDatabase() {
         -- Create index on username and email
         CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
         CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-      `);
+      `
+      });
     }
 
     // Create scrapyard_items table if not exists
@@ -122,7 +124,8 @@ async function initializeDatabase() {
 
     if (itemsError && itemsError.code === '42P01') { // Table doesn't exist
       console.log('Creating scrapyard_items table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE scrapyard_items (
           id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
           title TEXT NOT NULL,
@@ -146,7 +149,8 @@ async function initializeDatabase() {
         -- Create indexes
         CREATE INDEX IF NOT EXISTS idx_scrapyard_items_creator ON scrapyard_items(creator);
         CREATE INDEX IF NOT EXISTS idx_scrapyard_items_category ON scrapyard_items(category);
-      `);
+      `
+      });
     }
 
     // Create sessions table if not exists
@@ -157,7 +161,8 @@ async function initializeDatabase() {
 
     if (sessionsError && sessionsError.code === '42P01') { // Table doesn't exist
       console.log('Creating sessions table...');
-      await supabaseAdmin.query(`
+      await supabaseAdmin.rpc('execute_sql', {
+        sql: `
         CREATE TABLE sessions (
           sid varchar NOT NULL PRIMARY KEY,
           sess json NOT NULL,
@@ -165,7 +170,8 @@ async function initializeDatabase() {
         );
 
         CREATE INDEX IF NOT EXISTS idx_sessions_expired ON sessions(expired);
-      `);
+      `
+      });
     }
 
     console.log('Database initialization complete');


### PR DESCRIPTION
## Summary
- use `execute_sql` RPC for initializing DB tables
- adjust migration scripts to call RPC instead of `.query`
- add missing `server/models/Item.js`

## Testing
- `npm test` *(fails: fetch errors and module issues)*

------
https://chatgpt.com/codex/tasks/task_e_68450e64dd24832f8bd07252b8d015db