### PR TITLE
Fix ScrapyardItem mocks

### DIFF
--- a/tests/server/routes/index.test.js
+++ b/tests/server/routes/index.test.js
@@ -9,10 +9,14 @@ jest.mock('../../../server/models/User', () => ({
   findRecent: jest.fn().mockResolvedValue([
     { username: 'testuser1', displayName: 'Test User 1' },
     { username: 'testuser2', displayName: 'Test User 2' }
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2),
+  find: jest.fn().mockResolvedValue([
+    { username: 'recentuser', lastActive: new Date().toISOString() }
   ])
 }));
 
-jest.mock('../../../server/models/Item', () => ({
+jest.mock('../../../server/models/ScrapyardItem', () => ({
   findRecent: jest.fn().mockResolvedValue([
     { id: 1, title: 'Test Item 1' },
     { id: 2, title: 'Test Item 2' }
@@ -20,7 +24,8 @@ jest.mock('../../../server/models/Item', () => ({
   findFeatured: jest.fn().mockResolvedValue([
     { id: 3, title: 'Featured Item 1' },
     { id: 4, title: 'Featured Item 2' }
-  ])
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2)
 }));
 
 // Mock express-handlebars


### PR DESCRIPTION
## Summary
- update mocks in `index.test.js` to reference `ScrapyardItem`
- mock `countDocuments` and other methods to satisfy route dependencies

## Testing
- `npx jest --runTestsByPath tests/server/routes/index.test.js --silent`
- `npm test --silent` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68450e581b70832f8ad5f17e9954db19