### PR TITLE
Add stop function for health checks

### DIFF
--- a/server.js
+++ b/server.js
@@ -394,7 +394,9 @@ const gracefulShutdown = async () => {
   try {
     // Stop health checks and leak detection
     console.log('Stopping database monitoring...');
-    clearInterval(healthCheckTimer);
+    if (healthCheckTimer && typeof healthCheckTimer.stop === 'function') {
+      healthCheckTimer.stop();
+    }
     clearInterval(leakDetectionTimers.checkTimer);
     clearInterval(leakDetectionTimers.fixTimer);
 

--- a/server/utils/db-health.js
+++ b/server/utils/db-health.js
@@ -157,14 +157,14 @@ const performMaintenance = async (knex = null) => {
  * Start periodic health checks
  * @param {Object} knexInstance - The knex instance to use
  * @param {number} interval - Check interval in milliseconds
- * @returns {Object} Timer object
+ * @returns {Object} Object containing the timer and a stop function
  */
 const startPeriodicHealthChecks = (knex = null, interval = 60000) => {
   const kInstance = knex || knexInstance || global.knex;
 
   if (!kInstance) {
     console.error('ERROR: No knex instance available for health checks');
-    return null;
+    return { timer: null, stop: () => {} };
   }
 
   // Store the instance for future use
@@ -187,7 +187,12 @@ const startPeriodicHealthChecks = (knex = null, interval = 60000) => {
 
   console.log(`Database health checks started (interval: ${interval}ms)`);
 
-  return timer;
+  const stop = () => {
+    clearInterval(timer);
+    console.log('Database health checks stopped');
+  };
+
+  return { timer, stop };
 };
 
 /**


### PR DESCRIPTION
## Summary
- return a stop function from `startPeriodicHealthChecks`
- use the stop function during graceful shutdown

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450e424ca4832f9bd8ab894b38ea88

## Summary by Sourcery

Provide a stop mechanism for periodic database health checks and invoke it during graceful shutdown

Enhancements:
- Return an object with timer and stop function from startPeriodicHealthChecks
- Add a no-op stop function fallback when no knex instance is available
- Use the returned stop function in gracefulShutdown to stop health checks