### PR TITLE
Improve API error reporting

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -23,7 +23,10 @@ router.get('/users', async (req, res) => {
     res.json(users);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({
+      error: 'Server error',
+      message: process.env.NODE_ENV !== 'production' ? err.message : undefined
+    });
   }
 });
 
@@ -40,7 +43,10 @@ router.get('/users/:username', async (req, res) => {
     res.json(user);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({
+      error: 'Server error',
+      message: process.env.NODE_ENV !== 'production' ? err.message : undefined
+    });
   }
 });
 
@@ -56,7 +62,10 @@ router.get('/me', ensureAuthenticated, async (req, res) => {
     res.json(user);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({
+      error: 'Server error',
+      message: process.env.NODE_ENV !== 'production' ? err.message : undefined
+    });
   }
 });
 
@@ -74,7 +83,10 @@ router.get('/scrapyard', async (req, res) => {
     res.json(items);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({
+      error: 'Server error',
+      message: process.env.NODE_ENV !== 'production' ? err.message : undefined
+    });
   }
 });
 
@@ -91,7 +103,10 @@ router.get('/scrapyard/:id', async (req, res) => {
     res.json(item);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({
+      error: 'Server error',
+      message: process.env.NODE_ENV !== 'production' ? err.message : undefined
+    });
   }
 });
 
@@ -135,7 +150,10 @@ router.get('/market/items', async (req, res) => {
     });
   } catch (error) {
     console.error('Error fetching market items:', error);
-    res.status(500).json({ error: 'An error occurred while fetching marketplace items' });
+    res.status(500).json({
+      error: 'An error occurred while fetching marketplace items',
+      message: process.env.NODE_ENV !== 'production' ? error.message : undefined
+    });
   }
 });
 
@@ -151,7 +169,10 @@ router.get('/market/items/:id', async (req, res) => {
     res.json(item);
   } catch (error) {
     console.error('Error fetching market item:', error);
-    res.status(500).json({ error: 'An error occurred while fetching the marketplace item' });
+    res.status(500).json({
+      error: 'An error occurred while fetching the marketplace item',
+      message: process.env.NODE_ENV !== 'production' ? error.message : undefined
+    });
   }
 });
 
@@ -182,7 +203,7 @@ router.post('/streetpass/visit', ensureAuthenticated, async (req, res) => {
     res.status(500).json({
       success: false,
       message: 'Failed to record visit',
-      error: process.env.NODE_ENV === 'development' ? error.message : 'Server error'
+      error: process.env.NODE_ENV !== 'production' ? error.message : 'Server error'
     });
   }
 });
@@ -208,7 +229,7 @@ router.get('/streetpass/visitors/:profileId', async (req, res) => {
     res.status(500).json({
       success: false,
       message: 'Failed to get visitors',
-      error: process.env.NODE_ENV === 'development' ? error.message : 'Server error'
+      error: process.env.NODE_ENV !== 'production' ? error.message : 'Server error'
     });
   }
 });
@@ -237,7 +258,7 @@ router.put('/streetpass/emote', ensureAuthenticated, async (req, res) => {
     res.status(500).json({
       success: false,
       message: 'Failed to update emote',
-      error: process.env.NODE_ENV === 'development' ? error.message : 'Server error'
+      error: process.env.NODE_ENV !== 'production' ? error.message : 'Server error'
     });
   }
 });


### PR DESCRIPTION
## Summary
- show error.message when API errors occur and not in production
- adjust streetpass routes to use NODE_ENV !== 'production'

## Testing
- `npm test` *(fails: Missing required Supabase env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450e28c0ac832fb1008eabbce0442d

## Summary by Sourcery

Improve API error reporting by exposing detailed error messages in non-production environments and standardize environment checks for streetpass routes.

Enhancements:
- Augment all server API error responses to include the original error message when NODE_ENV is not production
- Replace development-only checks in streetpass routes with a unified production check (NODE_ENV !== 'production') for error handling