### PR TITLE
Refresh balance and session after purchase

### DIFF
--- a/server/routes/market-api.js
+++ b/server/routes/market-api.js
@@ -13,6 +13,7 @@ const { apiCache } = require('../utils/performance');
 const MarketItem = require('../models/MarketItem');
 const Collection = require('../models/Collection');
 const WIRTransaction = require('../models/WIRTransaction');
+const User = require('../models/User');
 
 /**
  * GET /api/market/items
@@ -502,6 +503,16 @@ router.post('/items/:id/purchase', ensureApiAuth, async (req, res) => {
     const itemId = req.params.id;
     const userId = req.user.id;
 
+    // Refresh user's balance from the database
+    const freshUser = await User.findById(userId);
+    if (!freshUser) {
+      return res.status(400).json({
+        success: false,
+        message: 'User not found'
+      });
+    }
+    req.user.wirBalance = freshUser.wirBalance;
+
     // Get the item details
     const item = await MarketItem.getById(itemId);
 
@@ -533,6 +544,22 @@ router.post('/items/:id/purchase', ensureApiAuth, async (req, res) => {
     const result = await MarketItem.purchase(itemId, userId);
 
     if (result.success) {
+      // Update user's WIR balance in session
+      req.user.wirBalance = result.newBalance;
+
+      // Refresh session data
+      const updatedUser = await User.findById(userId);
+      if (updatedUser) {
+        await new Promise(resolve => {
+          req.login(updatedUser, err => {
+            if (err) {
+              console.error('Error updating session after purchase:', err);
+            }
+            resolve();
+          });
+        });
+      }
+
       return res.json({
         success: true,
         message: 'Purchase successful',


### PR DESCRIPTION
## Summary
- refresh user's WIR balance from the DB before purchase
- update the session with the new balance once purchase completes

## Testing
- `npm test` *(fails: missing Supabase env variables)*

------
https://chatgpt.com/codex/tasks/task_e_684501377bc0832f8df735d728904a33

## Summary by Sourcery

Refresh the user’s WIR balance from the database before processing a purchase and update the session with the new balance after purchase in both API and UI market routes.

Enhancements:
- Add balance refresh step before item purchase to ensure the session has the latest WIR balance
- Update session data with the user's new WIR balance after a successful purchase for both API and browser routes