### PR TITLE
Limit DOMPurify fallback warnings

### DIFF
--- a/server/utils/handlebars-helpers.js
+++ b/server/utils/handlebars-helpers.js
@@ -3,6 +3,8 @@
  */
 // Import DOMPurify for HTML sanitization
 let DOMPurify;
+// Flag to ensure fallback warning only logs once
+let fallbackWarningShown = false;
 try {
   // DOMPurify requires a DOM environment, so we need to use jsdom in Node.js
   const createDOMPurify = require('dompurify');
@@ -11,10 +13,14 @@ try {
   DOMPurify = createDOMPurify(window);
   console.log('DOMPurify initialized with JSDOM');
 } catch (err) {
-  console.warn('DOMPurify module not found, using fallback implementation:', err.message);
+  const warningMessage = 'DOMPurify module not found, using fallback implementation: ' + err.message;
   // Simple fallback implementation
   DOMPurify = {
     sanitize: function(content, options) {
+      if (!fallbackWarningShown) {
+        console.warn(warningMessage);
+        fallbackWarningShown = true;
+      }
       // Basic sanitization - in a real app, use a proper HTML sanitizer
       return content
         .replace(/&/g, '&amp;')


### PR DESCRIPTION
## Summary
- only warn once when falling back to simple DOMPurify implementation

## Testing
- `npm test` *(fails: Cannot find module '../../../server/models/Item')*

------
https://chatgpt.com/codex/tasks/task_e_68450e1868c0832fac4f442a5f29e957

## Summary by Sourcery

Enhancements:
- Add a flag to limit the fallback DOMPurify warning to a single console message