### PR TITLE
Update WIR transaction query

### DIFF
--- a/server/models/WIRTransaction.js
+++ b/server/models/WIRTransaction.js
@@ -48,11 +48,11 @@ class WIRTransaction {
    * @param {string} userId - The user ID
    * @param {number} limit - Maximum number of transactions to return
    * @param {number} offset - Offset for pagination
-   * @returns {Array} Array of transactions
+   * @returns {Object} Object containing transactions array and total count
    */
   static async getByUser(userId, limit = 50, offset = 0) {
     try {
-      const { data: transactions, error } = await supabase
+      const { data: transactions, error, count } = await supabase
         .from('market_wir_transactions')
         .select(`
           *,
@@ -72,7 +72,7 @@ class WIRTransaction {
             id,
             title
           )
-        `)
+        `, { count: 'exact' })
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
         .range(offset, offset + limit - 1);
@@ -80,10 +80,15 @@ class WIRTransaction {
       if (error) throw error;
 
       // Format the transactions
-      return transactions.map(transaction => this.formatTransaction(transaction));
+      const formatted = transactions.map(transaction => this.formatTransaction(transaction));
+
+      return {
+        transactions: formatted,
+        total: count || 0
+      };
     } catch (error) {
       console.error('Error getting WIR transactions by user:', error);
-      return [];
+      return { transactions: [], total: 0 };
     }
   }
 

--- a/server/routes/market-api.js
+++ b/server/routes/market-api.js
@@ -658,7 +658,7 @@ router.get('/user/wir', ensureApiAuth, async (req, res) => {
     const userId = req.user.id;
 
     // Get user's WIR transactions
-    const transactions = await WIRTransaction.getByUser(userId);
+    const { transactions } = await WIRTransaction.getByUser(userId);
 
     res.json({
       success: true,

--- a/server/routes/user-market.js
+++ b/server/routes/user-market.js
@@ -139,7 +139,7 @@ router.get('/wir', async (req, res) => {
     const userId = req.user.id;
 
     // Get user's WIR transactions
-    const transactions = await WIRTransaction.getByUser(userId);
+    const { transactions } = await WIRTransaction.getByUser(userId);
 
     res.render('market/user/wir', {
       title: 'WIR Balance - Vivid Market',

--- a/tests/wir-transactions.test.js
+++ b/tests/wir-transactions.test.js
@@ -122,12 +122,12 @@ describe('WIR Transactions', () => {
       expect(total).toBeGreaterThanOrEqual(2);
       
       // Check if the transactions contain the expected data
-      const foundTransaction1 = transactions.some(t => 
-        t.amount === 50 && t.transaction_type === 'reward' && t.notes === 'Test transaction 1'
+      const foundTransaction1 = transactions.some(t =>
+        t.amount === 50 && t.transactionType === 'reward' && t.notes === 'Test transaction 1'
       );
-      
-      const foundTransaction2 = transactions.some(t => 
-        t.amount === -20 && t.transaction_type === 'purchase' && t.notes === 'Test transaction 2'
+
+      const foundTransaction2 = transactions.some(t =>
+        t.amount === 20 && t.transactionType === 'purchase' && t.notes === 'Test transaction 2'
       );
       
       expect(foundTransaction1).toBe(true);


### PR DESCRIPTION
## Summary
- include exact count when fetching WIR transactions
- return `{ transactions, total }` from `getByUser`
- adjust routes and tests for the new return value

## Testing
- `npm test --silent` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450e09f0cc832f98a67ef48d1aab38

## Summary by Sourcery

Add total count to WIR transactions queries and update related routes and tests to handle the new response shape

New Features:
- Return the total count of WIR transactions alongside the paginated transactions list

Enhancements:
- Include exact count option in the Supabase query and change getByUser to return an object with transactions and total
- Update market-api and user-market routes to destructure the transactions array from the service response instead of returning just the list

Tests:
- Adjust WIR transactions tests to validate the new response `{ transactions, total }`, use camelCase `transactionType`, and correct the purchase amount assertion