### PR TITLE
Add email validation and tests

### DIFF
--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -1,0 +1,2 @@
+// Placeholder Item model for tests
+module.exports = {};

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -55,6 +55,12 @@ router.post('/register', async (req, res) => {
     errors.push({ msg: 'Password should be at least 6 characters' });
   }
 
+  // Validate email format
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (email && !emailRegex.test(email)) {
+    errors.push({ msg: 'Please enter a valid email address' });
+  }
+
   // Check username format and length
   if (username && (username.length < 3 || username.length > 20)) {
     errors.push({ msg: 'Username must be between 3 and 20 characters' });
@@ -192,7 +198,23 @@ router.get('/settings', ensureAuthenticated, (req, res) => {
 // Update account settings
 router.post('/settings', ensureAuthenticated, async (req, res) => {
   const { displayName, email, statusMessage, customGlyph } = req.body;
-  
+  const errors = [];
+
+  // Validate email format if provided
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (email && !emailRegex.test(email)) {
+    errors.push({ msg: 'Please enter a valid email address' });
+  }
+
+  if (errors.length > 0) {
+    return res.render('users/settings', {
+      title: 'Account Settings - Wirebase',
+      user: req.user,
+      errors,
+      pageTheme: 'dark-dungeon'
+    });
+  }
+
   try {
     // Prepare update data
     const updateData = {

--- a/tests/server/routes/index.test.js
+++ b/tests/server/routes/index.test.js
@@ -4,13 +4,16 @@
 const request = require('supertest');
 const express = require('express');
 
-// Mock dependencies
-jest.mock('../../../server/models/User', () => ({
+jest.mock("../../../server/models/User", () => ({
   findRecent: jest.fn().mockResolvedValue([
-    { username: 'testuser1', displayName: 'Test User 1' },
-    { username: 'testuser2', displayName: 'Test User 2' }
-  ])
+    { username: "testuser1", displayName: "Test User 1" },
+    { username: "testuser2", displayName: "Test User 2" }
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2),
+  find: jest.fn().mockResolvedValue([{ lastActive: new Date().toISOString() }])
 }));
+
+// Mock dependencies
 
 jest.mock('../../../server/models/Item', () => ({
   findRecent: jest.fn().mockResolvedValue([
@@ -21,6 +24,19 @@ jest.mock('../../../server/models/Item', () => ({
     { id: 3, title: 'Featured Item 1' },
     { id: 4, title: 'Featured Item 2' }
   ])
+}));
+
+// The index route uses ScrapyardItem, so mock it as well
+jest.mock('../../../server/models/ScrapyardItem', () => ({
+  findRecent: jest.fn().mockResolvedValue([
+    { id: 1, title: 'Test Item 1' },
+    { id: 2, title: 'Test Item 2' }
+  ]),
+  findFeatured: jest.fn().mockResolvedValue([
+    { id: 3, title: 'Featured Item 1' },
+    { id: 4, title: 'Featured Item 2' }
+  ]),
+  countDocuments: jest.fn().mockResolvedValue(2)
 }));
 
 // Mock express-handlebars

--- a/tests/server/routes/users.test.js
+++ b/tests/server/routes/users.test.js
@@ -1,0 +1,54 @@
+const request = require('supertest');
+const express = require('express');
+
+// Mock dependencies
+jest.mock('../../../server/models/User', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  create: jest.fn().mockResolvedValue({ id: '1' })
+}));
+
+// Mock express-handlebars
+jest.mock('express-handlebars', () => ({
+  engine: () => jest.fn()
+}));
+
+const usersRouter = require('../../../server/routes/users');
+
+const app = express();
+app.use(express.urlencoded({ extended: false }));
+app.set('view engine', 'handlebars');
+app.set('views', './server/views');
+
+app.use((req, res, next) => {
+  res.render = jest.fn().mockImplementation((view, options) => {
+    res.send({ view, options });
+  });
+  req.flash = jest.fn();
+  next();
+});
+
+app.use('/users', usersRouter);
+
+describe('User Routes', () => {
+  describe('POST /users/register', () => {
+    it('should reject invalid email format', async () => {
+      const response = await request(app)
+        .post('/users/register')
+        .type('form')
+        .send({
+          username: 'testuser',
+          email: 'invalid_email',
+          password: 'password',
+          password2: 'password'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.view).toBe('users/register');
+      expect(response.body.options.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Please enter a valid email address' })
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate email with regex during registration and settings update
- provide placeholder Item model for tests
- add unit tests for users router
- fix index route tests by mocking ScrapyardItem

## Testing
- `npm test` *(fails: WIR transaction tests require external services)*

------
https://chatgpt.com/codex/tasks/task_e_68450e062c98832fa5e6a45062e6b6dd