### PR TITLE
Update installation cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can use these accounts to explore the platform:
 1. Clone the repository
    ```
    git clone https://github.com/yourusername/wirebase.git
-   cd wirebase
+   cd wirebase-social
    ```
 
 2. Install dependencies


### PR DESCRIPTION
## Summary
- update `cd` command in the Installation section of README

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450df103cc832fb822f66fc0d3f529

## Summary by Sourcery

Documentation:
- Correct the `cd` command in the installation section to `cd wirebase-social`