### PR TITLE
Add WIRTransaction invalid direction test

### DIFF
--- a/tests/wir-transactions.test.js
+++ b/tests/wir-transactions.test.js
@@ -178,5 +178,41 @@ describe('WIR Transactions', () => {
       // Restore the original implementation
       jest.restoreAllMocks();
     });
+
+    it('should handle invalid conversion direction', async () => {
+      // Mock user data
+      const mockUser = {
+        id: testSenderId,
+        wir_balance: 100,
+        loot_tokens: 50
+      };
+
+      // Mock the supabase query for getting user
+      jest.spyOn(supabase, 'from').mockImplementation((table) => {
+        if (table === 'users') {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: mockUser, error: null })
+              })
+            }),
+            update: () => ({
+              eq: () => Promise.resolve({ error: null })
+            })
+          };
+        }
+
+        return supabase.from(table);
+      });
+
+      const result = await WIRTransaction.convert(testSenderId, 'invalid', 10);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Invalid conversion direction'
+      });
+
+      jest.restoreAllMocks();
+    });
   });
 });


### PR DESCRIPTION
### **User description**
## Summary
- extend tests for `WIRTransaction.convert`
- verify invalid conversion direction returns expected failure result

## Testing
- `SUPABASE_KEY=foo SUPABASE_SERVICE_KEY=bar npm test` *(fails: Cannot find module '../../../server/models/Item')*

------
https://chatgpt.com/codex/tasks/task_e_68450de381f4832f89f2521b7794259e


___

### **PR Type**
Tests


___

### **Description**
- Add test for invalid conversion direction in `WIRTransaction.convert`

- Mock user data and Supabase queries for invalid direction test

- Verify failure result and error message for invalid direction


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wir-transactions.test.js</strong><dd><code>Add test for invalid conversion direction in WIRTransaction</code></dd></summary>
<hr>

tests/wir-transactions.test.js

<li>Added a test case for invalid conversion direction in <br><code>WIRTransaction.convert</code><br> <li> Mocked user data and Supabase queries for the new test<br> <li> Checked that the function returns a failure result with the correct <br>message


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/75/files#diff-903d8620040071f3d395bc913be1a68392102fd13dca3574077d0e7826f8c15b">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>