### PR TITLE
Refactor feed queries for Supabase joins

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -66,10 +66,10 @@ router.get('/scrapyard', async (req, res) => {
     const category = req.query.category;
     const query = category ? { category } : {};
 
-    const items = await ScrapyardItem.find(query)
-      .sort({ createdAt: -1 })
-      .limit(20)
-      .populate('creator', 'username displayName avatar customGlyph');
+    const items = await ScrapyardItem.find(
+      query,
+      { sort: { createdAt: -1 }, limit: 20 }
+    );
 
     res.json(items);
   } catch (err) {
@@ -81,8 +81,7 @@ router.get('/scrapyard', async (req, res) => {
 // GET scrapyard item by ID
 router.get('/scrapyard/:id', async (req, res) => {
   try {
-    const item = await ScrapyardItem.findById(req.params.id)
-      .populate('creator', 'username displayName avatar customGlyph');
+    const item = await ScrapyardItem.findById(req.params.id);
 
     if (!item) {
       return res.status(404).json({ error: 'Item not found' });

--- a/server/routes/feed.js
+++ b/server/routes/feed.js
@@ -31,11 +31,7 @@ router.get('/', async (req, res) => {
         .limit(20)
         .select('username displayName avatar customGlyph statusMessage lastActive'),
         
-      ScrapyardItem.find()
-        .sort({ createdAt: -1 })
-        .limit(20)
-        .populate('creator', 'username displayName avatar customGlyph')
-        .select('title category description previewImage createdAt creator')
+      ScrapyardItem.find({}, { sort: { createdAt: -1 }, limit: 20 })
     ]);
 
     // Add recent user updates to feed
@@ -127,9 +123,10 @@ router.get('/user/:username', async (req, res) => {
     });
     
     // Get user's items in the Scrapyard
-    const userItems = await ScrapyardItem.find({ creator: user._id })
-      .sort({ createdAt: -1 })
-      .limit(20);
+    const userItems = await ScrapyardItem.find(
+      { creator: user._id },
+      { sort: { createdAt: -1 }, limit: 20 }
+    );
     
     // Add items to feed
     userItems.forEach(item => {
@@ -211,10 +208,10 @@ router.get('/scrapyard/:category', async (req, res) => {
     const query = category === 'all' ? {} : { category: category };
     
     // Get recent items
-    const items = await ScrapyardItem.find(query)
-      .sort({ createdAt: -1 })
-      .limit(30)
-      .populate('creator', 'username displayName');
+    const items = await ScrapyardItem.find(
+      query,
+      { sort: { createdAt: -1 }, limit: 30 }
+    );
     
     // Add items to feed
     items.forEach(item => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -139,12 +139,10 @@ router.get('/discover', async (req, res) => {
         .select('username displayName avatar customGlyph statusMessage lastActive'),
 
       // Recent Scrapyard submissions
-      ScrapyardItem.find()
-        .sort({ createdAt: -1 })
-        .skip(skip)
-        .limit(limit)
-        .populate('creator', 'username displayName avatar customGlyph')
-        .select('title category previewImage createdAt creator')
+      ScrapyardItem.find(
+        {},
+        { sort: { createdAt: -1 }, skip, limit }
+      )
     ]);
 
     // Count total documents for pagination


### PR DESCRIPTION
## Summary
- use ScrapyardItem.find with query options instead of populate
- rely on ScrapyardItem.findById for creator join
- drop populate logic in API and discovery routes

## Testing
- `npm test` *(fails: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68450dd69ab8832f9524a9e3e4760c5f