### PR TITLE
Add Docker configuration for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["node","server.js"]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ PORT=3000
 NODE_ENV=development
 ```
 
+## Docker Usage
+
+To run Wirebase locally with Docker:
+
+1. Create a `.env` file using the environment variables shown above.
+2. Build and start the containers:
+   ```bash
+   docker-compose up --build
+   ```
+   The app will be available at `http://localhost:3000`.
+
 ## License
 
 This project is available under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/wirebase
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      - SESSION_SECRET=${SESSION_SECRET}
+    depends_on:
+      - db
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: wirebase
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add a Dockerfile for running the Node server
- add docker-compose setup with Postgres
- document Docker usage

## Testing
- `npm test` *(fails: Cannot find module and missing Supabase env)*

------
https://chatgpt.com/codex/tasks/task_e_68450dc76f68832f93ce610070f06a70