### PR TITLE
Restore frontend pages and fix route priority

### DIFF
--- a/server.js
+++ b/server.js
@@ -140,11 +140,6 @@ app.use(resourceHints); // Add resource hints
 app.use(xssMiddleware); // Prevent XSS attacks
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(express.static(path.join(__dirname, 'public'), {
-  maxAge: '7d', // Cache static assets for 7 days
-  etag: true,
-  lastModified: true
-}));
 app.use(cacheControl); // Add cache control headers
 
 // Apply rate limiting to API routes
@@ -335,6 +330,13 @@ app.use('/admin/api', require('./server/routes/admin-api'));
 app.use('/market', require('./server/routes/market'));
 app.use('/market/user', require('./server/routes/user-market'));
 app.use('/api/market', require('./server/routes/market-api'));
+
+// Serve static assets after routes so dynamic pages take precedence
+app.use(express.static(path.join(__dirname, 'public'), {
+  maxAge: '7d', // Cache static assets for 7 days
+  etag: true,
+  lastModified: true
+}));
 
 // 404 handler
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- restore static HTML pages removed in previous commit
- move `express.static` middleware after routes so dynamic pages aren't overshadowed

## Testing
- `npm test` *(fails: Missing required Supabase environment variables, module mocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fd6e36f0832fadcc5b93d302e821