### PR TITLE
Add profile HTML/CSS edit templates

### DIFF
--- a/server/views/profile/edit-css.handlebars
+++ b/server/views/profile/edit-css.handlebars
@@ -1,0 +1,22 @@
+{{!< layouts/main}}
+
+<div class="profile-edit-container">
+    <div class="cyber-window edit-window">
+        <div class="cyber-window-header">
+            <span class="cyber-window-title">Edit Profile CSS</span>
+        </div>
+        <div class="cyber-window-content">
+            <form action="/profile/edit/css" method="POST">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                <div class="form-group">
+                    <label for="profileCss">CSS</label>
+                    <textarea id="profileCss" name="profileCss" rows="15" class="cyber-textarea code-editor">{{user.profileCss}}</textarea>
+                </div>
+                <div class="form-actions">
+                    <a href="/profile" class="cyber-button secondary">Cancel</a>
+                    <button type="submit" class="cyber-button">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/server/views/profile/edit-html.handlebars
+++ b/server/views/profile/edit-html.handlebars
@@ -1,0 +1,22 @@
+{{!< layouts/main}}
+
+<div class="profile-edit-container">
+    <div class="cyber-window edit-window">
+        <div class="cyber-window-header">
+            <span class="cyber-window-title">Edit Profile HTML</span>
+        </div>
+        <div class="cyber-window-content">
+            <form action="/profile/edit/html" method="POST">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                <div class="form-group">
+                    <label for="profileHtml">HTML</label>
+                    <textarea id="profileHtml" name="profileHtml" rows="15" class="cyber-textarea code-editor">{{user.profileHtml}}</textarea>
+                </div>
+                <div class="form-actions">
+                    <a href="/profile" class="cyber-button secondary">Cancel</a>
+                    <button type="submit" class="cyber-button">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add edit-html.handlebars and edit-css.handlebars views
- new forms allow HTML or CSS editing with CSRF protection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a1f39494832f81642ffb2ca0db40

## Summary by Sourcery

Add Handlebars templates for editing custom profile HTML and CSS, each backed by a CSRF-protected form.

New Features:
- Add profile HTML edit view and form with CSRF protection
- Add profile CSS edit view and form with CSRF protection