### PR TITLE
Add settings page

### DIFF
--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -1,0 +1,35 @@
+.account-settings-container {
+    min-height: 80vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 50px 20px;
+    position: relative;
+}
+
+.settings-window {
+    max-width: 600px;
+    width: 100%;
+    box-shadow: 0 0 30px rgba(0, 0, 0, 0.7);
+    position: relative;
+    z-index: 10;
+}
+
+.settings-errors {
+    background-color: rgba(255, 0, 0, 0.2);
+    border: 1px solid var(--cyber-red);
+    padding: 10px;
+    margin-bottom: 20px;
+}
+
+.settings-errors .error-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.section-divider {
+    margin: 30px 0;
+    border: none;
+    border-top: 1px solid var(--cyber-purple);
+}

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const glyphOptions = document.querySelectorAll('.glyph-option');
+  const glyphInput = document.getElementById('customGlyph');
+
+  glyphOptions.forEach(option => {
+    option.addEventListener('click', function() {
+      const glyph = this.getAttribute('data-glyph');
+      if (glyphInput) {
+        glyphInput.value = glyph;
+      }
+    });
+  });
+});

--- a/server/views/users/settings.handlebars
+++ b/server/views/users/settings.handlebars
@@ -1,0 +1,81 @@
+{{!< layouts/main}}
+
+{{#* content "additionalStyles"}}
+    <link rel="stylesheet" href="/css/settings.css">
+{{/content}}
+
+{{#* content "additionalScripts"}}
+    <script src="/js/settings.js" defer></script>
+{{/content}}
+
+<div class="account-settings-container">
+    <div class="cyber-window settings-window">
+        <div class="cyber-window-header">
+            <span class="cyber-window-title">Account Settings</span>
+        </div>
+        <div class="cyber-window-content">
+            {{#if errors}}
+                <div class="settings-errors">
+                    <ul class="error-list">
+                        {{#each errors}}
+                            <li><span class="error-icon">⚠️</span> {{this.msg}}</li>
+                        {{/each}}
+                    </ul>
+                </div>
+            {{/if}}
+            <form action="/users/settings" method="POST" class="settings-form">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                <div class="form-group">
+                    <label for="displayName">Display Name</label>
+                    <input type="text" id="displayName" name="displayName" class="cyber-input" value="{{displayName}}">
+                </div>
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email" class="cyber-input" value="{{email}}">
+                </div>
+                <div class="form-group">
+                    <label for="customGlyph">Custom Glyph</label>
+                    <div class="glyph-picker">
+                        <input type="text" id="customGlyph" name="customGlyph" class="cyber-input glyph-input" maxlength="2" value="{{customGlyph}}">
+                        <div class="glyph-options">
+                            <button type="button" class="glyph-option" data-glyph="👁️">👁️</button>
+                            <button type="button" class="glyph-option" data-glyph="💾">💾</button>
+                            <button type="button" class="glyph-option" data-glyph="🔌">🔌</button>
+                            <button type="button" class="glyph-option" data-glyph="📡">📡</button>
+                            <button type="button" class="glyph-option" data-glyph="🖥️">🖥️</button>
+                            <button type="button" class="glyph-option" data-glyph="🕸️">🕸️</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="statusMessage">Status Message</label>
+                    <input type="text" id="statusMessage" name="statusMessage" class="cyber-input" value="{{statusMessage}}">
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="cyber-button">Save Changes</button>
+                </div>
+            </form>
+
+            <hr class="section-divider">
+
+            <form action="/users/change-password" method="POST" class="password-form">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                <div class="form-group">
+                    <label for="currentPassword">Current Password</label>
+                    <input type="password" id="currentPassword" name="currentPassword" class="cyber-input" required>
+                </div>
+                <div class="form-group">
+                    <label for="newPassword">New Password</label>
+                    <input type="password" id="newPassword" name="newPassword" class="cyber-input" required>
+                </div>
+                <div class="form-group">
+                    <label for="confirmPassword">Confirm New Password</label>
+                    <input type="password" id="confirmPassword" name="confirmPassword" class="cyber-input" required>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="cyber-button">Change Password</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add account settings page to edit display name, email, glyph, status
- validate and save settings in `users` routes
- include simple JS glyph picker and CSS styles

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b5962a8832fb2b8f416462b1701

## Summary by Sourcery

Introduce a new account settings page and backend logic to allow users to update their profile fields and change their password

New Features:
- Add account settings page to update display name, email, custom glyph (via picker), status message, and change password

Enhancements:
- Include client-side glyph picker with associated CSS and JS assets
- Validate inputs (display name length, email format/uniqueness, glyph length) on the server and render errors inline
- Persist updated settings to the database and show success flash messages