### PR TITLE
Add password recovery view

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -149,17 +149,21 @@ router.get('/forgot-password', (req, res) => {
 // Handle password reset request
 router.post('/forgot-password', async (req, res, next) => {
   const { email } = req.body;
-  
+
   try {
-    const user = await User.findOne({ email });
-    
-    // Don't reveal if user exists or not for security
-    req.flash('success_msg', 'If an account with that email exists, a password reset link has been sent');
-    res.redirect('/users/login');
+    const { supabaseAdmin } = require('../utils/database');
+    // Request Supabase to send a password recovery email
+    await supabaseAdmin.auth.resetPasswordForEmail(email, {
+      redirectTo: `${req.protocol}://${req.get('host')}/users/login`
+    });
   } catch (err) {
     console.error(err);
-    next(err);
+    // Ignore errors to avoid revealing whether the email exists
   }
+
+  // Always show the same message for security
+  req.flash('success_msg', 'If an account with that email exists, a password reset link has been sent');
+  res.redirect('/users/login');
 });
 
 // Account settings page

--- a/server/views/users/forgot-password.handlebars
+++ b/server/views/users/forgot-password.handlebars
@@ -1,0 +1,53 @@
+{{!< layouts/main}}
+
+{{#* content "additionalStyles"}}
+    <link rel="stylesheet" href="/css/login.css">
+{{/content}}
+
+<div class="cyber-login-container">
+    <div class="glitch-container">
+        <div class="glitch-effect left"></div>
+        <div class="glitch-effect right"></div>
+    </div>
+
+    <div class="cyber-window login-window">
+        <div class="cyber-window-header">
+            <span class="cyber-window-title">password.recovery</span>
+            <div class="cyber-window-controls">
+                <span class="cyber-window-control">_</span>
+                <span class="cyber-window-control">□</span>
+                <span class="cyber-window-control">×</span>
+            </div>
+        </div>
+        <div class="cyber-window-content">
+            <div class="cyber-terminal">
+                <div class="login-header">
+                    <img src="/images/wirebase-logo.svg" alt="wirebase.city" class="login-logo">
+                    <h2>Reset Access Key</h2>
+                    <div class="separator">
+                        <span class="separator-icon">🔑</span>
+                    </div>
+                </div>
+
+                <form action="/users/forgot-password" method="POST" class="login-form">
+                    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                    <div class="form-group">
+                        <label for="email">Email Address</label>
+                        <input type="email" id="email" name="email" class="cyber-input" required>
+                    </div>
+                    <p class="reset-help">Enter your account email and we'll send you instructions to reset your password.</p>
+                    <div class="form-actions">
+                        <button type="submit" class="cyber-button">Send Link</button>
+                        <a href="/users/login" class="forgot-link">Back to Login</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="cyber-decorations">
+        <div class="decoration circuit left"></div>
+        <div class="decoration circuit right"></div>
+        <div class="decoration static"></div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- allow users to request password reset from `/users/forgot-password`
- send Supabase password recovery email when form is submitted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b5c1370832fab9535459e4f033e