### PR TITLE
Add item HTML viewer

### DIFF
--- a/public/css/vivid-market.css
+++ b/public/css/vivid-market.css
@@ -690,6 +690,17 @@
   margin-top: 20px;
 }
 
+.item-html-container {
+  max-height: 60vh;
+  overflow-y: auto;
+  background-color: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  padding: 15px;
+  margin-top: 10px;
+  font-family: monospace;
+  color: var(--text-light);
+}
+
 /* Notification */
 .toast-container {
   position: fixed;

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
   initializeNotifications();
   initializeModalHandlers();
   initializePurchaseFlow();
+  initializeItemHtmlViewer();
 });
 
 /**
@@ -391,4 +392,56 @@ function initializePurchaseFlow() {
  */
 function isUserLoggedIn() {
   return document.body.classList.contains('user-logged-in');
+}
+
+/**
+ * Initialize item HTML viewer buttons
+ */
+function initializeItemHtmlViewer() {
+  const htmlButtons = document.querySelectorAll('.view-html-button');
+  if (!htmlButtons.length) return;
+
+  htmlButtons.forEach(button => {
+    button.addEventListener('click', async function(e) {
+      e.preventDefault();
+
+      const itemId = this.dataset.itemId;
+      const modalId = this.dataset.modalTarget;
+      if (!itemId) return;
+
+      try {
+        const response = await fetch(`/api/market/items/${itemId}`);
+        const data = await response.json();
+
+        if (!response.ok || !data.success) {
+          throw new Error(data.message || 'Error loading item');
+        }
+
+        const htmlContent = data.item.content || '<p>No HTML available.</p>';
+
+        if (modalId) {
+          const modal = document.getElementById(modalId);
+          if (modal) {
+            const container = modal.querySelector('.item-html-container');
+            if (container) container.innerHTML = htmlContent;
+            modal.style.display = 'block';
+          }
+        } else {
+          let container = this.closest('.market-item');
+          if (container) {
+            let htmlEl = container.querySelector('.item-html-container');
+            if (!htmlEl) {
+              htmlEl = document.createElement('div');
+              htmlEl.className = 'item-html-container';
+              container.appendChild(htmlEl);
+            }
+            htmlEl.innerHTML = htmlContent;
+          }
+        }
+      } catch (error) {
+        console.error('Error loading item HTML:', error);
+        showNotification('Error loading item HTML', 'error');
+      }
+    });
+  });
 }

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -411,9 +411,14 @@ function initializeItemHtmlViewer() {
 
       try {
         const response = await fetch(`/api/market/items/${itemId}`);
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
         const data = await response.json();
 
-        if (!response.ok || !data.success) {
+        if (!data.success) {
           throw new Error(data.message || 'Error loading item');
         }
 

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -405,7 +405,7 @@ function initializeItemHtmlViewer() {
     button.addEventListener('click', async function(e) {
       e.preventDefault();
 
-      const itemId = this.dataset.itemId;
+      const {itemId} = this.dataset;
       const modalId = this.dataset.modalTarget;
       if (!itemId) return;
 

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -435,7 +435,7 @@ function initializeItemHtmlViewer() {
               htmlEl.className = 'item-html-container';
               container.appendChild(htmlEl);
             }
-            htmlEl.innerHTML = htmlContent;
+            htmlEl.textContent = htmlContent;
           }
         }
       } catch (error) {

--- a/public/js/vivid-market.js
+++ b/public/js/vivid-market.js
@@ -423,7 +423,7 @@ function initializeItemHtmlViewer() {
           const modal = document.getElementById(modalId);
           if (modal) {
             const container = modal.querySelector('.item-html-container');
-            if (container) container.innerHTML = htmlContent;
+            if (container) container.textContent = htmlContent;
             modal.style.display = 'block';
           }
         } else {

--- a/views/market/item.ejs
+++ b/views/market/item.ejs
@@ -93,6 +93,14 @@
             </span>
           <% } %>
         </div>
+        <div style="text-align: right; margin-top: 10px;">
+          <button class="view-html-button action-button"
+                  data-item-id="<%= item.id %>"
+                  data-modal-target="item-html-modal">
+            <i class="button-icon fa fa-code"></i>
+            <span class="button-text">View HTML</span>
+          </button>
+        </div>
       </div>
       
       <% if (item.collection) { %>
@@ -151,6 +159,16 @@
       <div class="modal-actions">
         <button class="cancel-button close-modal">Cancel</button>
         <button class="submit-button confirm-purchase-button">Confirm Purchase</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="item-html-modal" class="modal">
+    <div class="modal-content">
+      <span class="close-modal">&times;</span>
+      <h2>Item HTML Preview</h2>
+      <div class="item-html-container">
+        Loading...
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show item HTML in a modal
- style modal HTML container
- implement item HTML viewer button logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b69dfec832f8408ae98ef688c9f

## Summary by Sourcery

Add an item HTML viewer feature allowing users to preview raw item HTML content in a modal dialog or inline container.

New Features:
- Add 'View HTML' button to item pages that opens a modal or inline container

Enhancements:
- Fetch item HTML via API and initialize click handlers to display it in the viewer
- Style the HTML preview container with scrollable, monospace layout