### PR TITLE
Add user avatar upload endpoint

### DIFF
--- a/server/views/layouts/main.handlebars
+++ b/server/views/layouts/main.handlebars
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="description" content="{{pageDescription}}">
     <meta name="theme-color" content="#0f0f0f">
+    <meta name="csrf-token" content="{{csrfToken}}">
     <title>{{title}}</title>
 
     {{!-- Preload critical assets --}}

--- a/server/views/profile/profile.handlebars
+++ b/server/views/profile/profile.handlebars
@@ -447,9 +447,12 @@
                             const formData = new FormData();
                             formData.append('avatar', fileInput.files[0]);
                             
+                            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
                             // Upload avatar
                             fetch('/api/user/avatar', {
                                 method: 'POST',
+                                headers: { 'CSRF-Token': csrfToken },
                                 body: formData
                             })
                             .then(response => response.json())

--- a/tests/server/routes/api-avatar.test.js
+++ b/tests/server/routes/api-avatar.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const multer = require('multer');
+
+jest.mock('../../../server/models/User', () => ({
+  findByIdAndUpdate: jest.fn()
+}));
+
+const fromMock = jest.fn();
+jest.mock('../../../server/utils/database', () => ({
+  supabase: { from: fromMock },
+  supabaseAdmin: {}
+}));
+
+const User = require('../../../server/models/User');
+
+let app;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    req.isAuthenticated = () => true;
+    req.user = { id: 'user1' };
+    next();
+  });
+
+  const storage = multer.diskStorage({
+    destination: (req, _file, cb) => {
+      const dir = path.join(os.tmpdir(), 'wirebase-tests');
+      fs.mkdirSync(dir, { recursive: true });
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => cb(null, file.originalname)
+  });
+  const upload = multer({ storage });
+  app.locals.upload = upload;
+
+  const apiRouter = require('../../../server/routes/api');
+  app.use('/api', apiRouter);
+});
+
+test('uploads avatar and updates user', async () => {
+  const tmpDir = path.join(os.tmpdir(), 'wirebase-tests');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const filePath = path.join(tmpDir, 'avatar.png');
+  fs.writeFileSync(filePath, 'test');
+
+  User.findByIdAndUpdate.mockResolvedValue({ id: 'user1', avatar: '/uploads/user1/avatar.png' });
+
+  const res = await request(app)
+    .post('/api/user/avatar')
+    .attach('avatar', filePath);
+
+  expect(res.status).toBe(200);
+  expect(res.body.success).toBe(true);
+  expect(User.findByIdAndUpdate).toHaveBeenCalledWith('user1', expect.objectContaining({ avatar: expect.stringContaining('/uploads/user1/') }));
+
+  fs.unlinkSync(filePath);
+});


### PR DESCRIPTION
## Summary
- allow users to upload avatars via POST `/api/user/avatar`
- expose CSRF token in layout and send it from profile page
- test avatar upload route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b6da1f4832f87945cb935379dff