### PR TITLE
Implement remember me session option

### DIFF
--- a/server.js
+++ b/server.js
@@ -222,7 +222,6 @@ app.use(session({
   rolling: false, // Disable rolling to reduce database writes
   name: 'wirebase.sid', // Custom cookie name for better security
   cookie: {
-    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
     httpOnly: true, // Prevent client-side JS from accessing cookie

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -135,7 +135,7 @@ router.post('/login', (req, res, next) => {
         req.session.cookie.maxAge = 30 * 24 * 60 * 60 * 1000;
       } else {
         // Session cookie expires on browser close
-        req.session.cookie.expires = false;
+        req.session.cookie.maxAge = null;
       }
       return res.redirect('/profile');
     });

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -130,7 +130,7 @@ router.post('/login', (req, res, next) => {
     }
     req.logIn(user, err => {
       if (err) { return next(err); }
-      if (req.body.remember) {
+      if (req.body.remember === 'on' || req.body.remember === true) {
         // Persist session for 30 days when remember is checked
         req.session.cookie.maxAge = 30 * 24 * 60 * 60 * 1000;
       } else {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -130,7 +130,8 @@ router.post('/login', (req, res, next) => {
     }
     req.logIn(user, err => {
       if (err) { return next(err); }
-      if (req.body.remember === 'on' || req.body.remember === true) {
+      const rememberMe = req.body.remember === 'on' || req.body.remember === true;
+      if (rememberMe) {
         // Persist session for 30 days when remember is checked
         req.session.cookie.maxAge = 30 * 24 * 60 * 60 * 1000;
       } else {


### PR DESCRIPTION
### **User description**
## Summary
- customize login flow to support remember me
- default sessions expire on browser close

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b71cf0c832f8e545ad59f089a11


___

### **PR Type**
Enhancement


___

### **Description**
- Implement remember me functionality for user sessions

- Remove default 7-day session expiration from server config

- Add conditional session duration based on checkbox state

- Sessions expire on browser close by default


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User Login"] --> B["Remember Me Checkbox"]
  B --> C{"Checkbox Checked?"}
  C -->|Yes| D["30-day Session"]
  C -->|No| E["Browser Close Session"]
  D --> F["Redirect to Profile"]
  E --> F["Redirect to Profile"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Remove default session expiration configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<li>Remove hardcoded 7-day <code>maxAge</code> from session cookie configuration<br> <li> Allow dynamic session duration based on login preferences


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/97/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>users.js</strong><dd><code>Add remember me session logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes/users.js

<li>Replace simple passport authentication with custom callback<br> <li> Add remember me checkbox logic for session duration<br> <li> Set 30-day session when remember is checked<br> <li> Default to browser-close session expiration


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/97/files#diff-f41fe31b04449be20188b550a50aad0471e31060960b9e36e3d5294b21f609de">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>