### PR TITLE
Use real forum counts in homepage stats widget

### DIFF
--- a/server/models/Reply.js
+++ b/server/models/Reply.js
@@ -234,7 +234,7 @@ class Reply {
         .select('id', { count: 'exact' });
 
       Object.entries(query).forEach(([key, value]) => {
-        const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+        const snakeKey = key.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
         supabaseQuery = supabaseQuery.eq(snakeKey, value);
       });
 

--- a/server/models/Reply.js
+++ b/server/models/Reply.js
@@ -231,7 +231,7 @@ class Reply {
     try {
       let supabaseQuery = supabase
         .from('forum_replies')
-        .select('id', { count: 'exact' });
+        .select('*', { count: 'exact', head: true });
 
       Object.entries(query).forEach(([key, value]) => {
         const snakeKey = key.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();

--- a/server/models/Reply.js
+++ b/server/models/Reply.js
@@ -223,6 +223,33 @@ class Reply {
   }
 
   /**
+   * Count replies that match a query
+   * @param {Object} query - Query filters
+   * @returns {Promise<number>} - Count of matching replies
+   */
+  static async countDocuments(query = {}) {
+    try {
+      let supabaseQuery = supabase
+        .from('forum_replies')
+        .select('id', { count: 'exact' });
+
+      Object.entries(query).forEach(([key, value]) => {
+        const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+        supabaseQuery = supabaseQuery.eq(snakeKey, value);
+      });
+
+      const { count, error } = await supabaseQuery;
+
+      if (error) throw error;
+
+      return count || 0;
+    } catch (error) {
+      console.error('Error counting replies:', error);
+      return 0;
+    }
+  }
+
+  /**
    * Format a reply object from database to application format
    * @param {Object} dbReply - Reply object from database
    * @returns {Object} Formatted reply object

--- a/server/models/Thread.js
+++ b/server/models/Thread.js
@@ -340,6 +340,33 @@ class Thread {
   }
 
   /**
+   * Count threads that match a query
+   * @param {Object} query - Query filters
+   * @returns {Promise<number>} - Count of matching threads
+   */
+  static async countDocuments(query = {}) {
+    try {
+      let supabaseQuery = supabase
+        .from('forum_threads')
+        .select('id', { count: 'exact' });
+
+      Object.entries(query).forEach(([key, value]) => {
+        const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+        supabaseQuery = supabaseQuery.eq(snakeKey, value);
+      });
+
+      const { count, error } = await supabaseQuery;
+
+      if (error) throw error;
+
+      return count || 0;
+    } catch (error) {
+      console.error('Error counting threads:', error);
+      return 0;
+    }
+  }
+
+  /**
    * Increment view count for a thread
    * @param {string} id - Thread ID
    * @returns {Promise<boolean>} Success status

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,8 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/User');
 const ScrapyardItem = require('../models/ScrapyardItem');
+const Thread = require('../models/Thread');
+const Reply = require('../models/Reply');
 
 // Enhanced error middleware
 const errorHandler = (err, req, res, next) => {
@@ -35,6 +37,8 @@ router.get('/', async (req, res) => {
       featuredItems,
       userCount,
       itemCount,
+      threadCount,
+      commentCount,
       recentActivity
     ] = await Promise.all([
       User.findRecent(),
@@ -42,6 +46,8 @@ router.get('/', async (req, res) => {
       ScrapyardItem.findFeatured(),
       User.countDocuments(),
       ScrapyardItem.countDocuments(),
+      Thread.countDocuments(),
+      Reply.countDocuments(),
       User.find({}, { sort: { lastActive: -1 }, limit: 10 })
     ]).catch(err => {
       throw new Error('Failed to fetch homepage data: ' + err.message);
@@ -83,8 +89,8 @@ router.get('/', async (req, res) => {
       stats: {
         userCount,
         itemCount,
-        threadCount: Math.floor(itemCount * 1.5), // Mock data for now
-        commentCount: Math.floor(itemCount * 4.2) // Mock data for now
+        threadCount,
+        commentCount
       },
       traffic: {
         hourlyData: hourlyTraffic,

--- a/tests/server/routes/index.test.js
+++ b/tests/server/routes/index.test.js
@@ -29,6 +29,14 @@ jest.mock('../../../server/models/ScrapyardItem', () => ({
   countDocuments: jest.fn().mockResolvedValue(2)
 }));
 
+jest.mock('../../../server/models/Thread', () => ({
+  countDocuments: jest.fn().mockResolvedValue(5)
+}));
+
+jest.mock('../../../server/models/Reply', () => ({
+  countDocuments: jest.fn().mockResolvedValue(10)
+}));
+
 // Mock express-handlebars
 jest.mock('express-handlebars', () => ({
   engine: () => jest.fn()


### PR DESCRIPTION
## Summary
- add countDocuments helpers to Thread and Reply models
- update homepage to use real counts
- mock new models in index route tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f2b762518832f94e49757d20d1119

## Summary by Sourcery

Use actual thread and reply counts in homepage stats instead of placeholder values

Enhancements:
- Add countDocuments helper to Thread and Reply models
- Update homepage route to fetch real threadCount and commentCount
- Remove mock calculations for thread and comment counts

Tests:
- Mock Thread and Reply countDocuments methods in index route tests