### PR TITLE
Handle API errors in Streetpass widget

### DIFF
--- a/public/components/streetpass-widget.js
+++ b/public/components/streetpass-widget.js
@@ -44,15 +44,20 @@ class StreetpassWidget extends HTMLElement {
 
         if (data.success && Array.isArray(data.visitors)) {
             // Transform API data to widget format
-            this.visitors = data.visitors.map(visitor => ({
-                id: visitor.id,
-                username: visitor.visitor.username,
-                displayName: visitor.visitor.displayName,
-                glyph: visitor.visitor.customGlyph,
-                timestamp: new Date(visitor.visitedAt).getTime(),
-                emote: visitor.emote || '👋',
-                visitId: visitor.id
-            }));
+            this.visitors = data.visitors.map(visitor => {
+                if (!visitor.visitor) {
+                    throw new Error('Invalid visitor data structure');
+                }
+                return {
+                    id: visitor.id,
+                    username: visitor.visitor.username,
+                    displayName: visitor.visitor.displayName,
+                    glyph: visitor.visitor.customGlyph,
+                    timestamp: new Date(visitor.visitedAt).getTime(),
+                    emote: visitor.emote || '👋',
+                    visitId: visitor.id
+                };
+            });
         } else {
             // Invalid data format
             throw new Error('API returned invalid data format');

--- a/public/components/streetpass-widget.js
+++ b/public/components/streetpass-widget.js
@@ -49,7 +49,7 @@ class StreetpassWidget extends HTMLElement {
                     throw new Error('Invalid visitor data structure');
                 }
                 return {
-                    id: visitor.id,
+                    timestamp: visitor.visitedAt ? new Date(visitor.visitedAt).getTime() : Date.now(),
                     username: visitor.visitor.username,
                     displayName: visitor.visitor.displayName,
                     glyph: visitor.visitor.customGlyph,


### PR DESCRIPTION
### **User description**
## Summary
- remove fallback fake visitor data
- show error state and retry correctly when loading visitors fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2b821ee0832fa3e7c47ae57ecd38


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove fallback fake visitor data from API failures

- Improve error handling with proper retry functionality

- Ensure consistent error state management across widget


___

### **Changes diagram**

```mermaid
flowchart LR
  A["API Call"] --> B{"Response OK?"}
  B -->|No| C["Throw Error"]
  B -->|Yes| D["Parse Data"]
  D --> E{"Valid Format?"}
  E -->|No| F["Throw Error"]
  E -->|Yes| G["Transform Data"]
  C --> H["Show Error State"]
  F --> H
  H --> I["Retry Button"]
  I --> A
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streetpass-widget.js</strong><dd><code>Remove fake fallback and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/components/streetpass-widget.js

<li>Removed try-catch wrapper and fake visitor fallback data<br> <li> Added proper error throwing for invalid API responses<br> <li> Enhanced retry button with complete error handling chain<br> <li> Simplified error flow by removing demo data fallback


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/100/files#diff-48251e8a53a53eef9038f622e0211108b9dfe15f82b27dfbbc7e4737a70a7bc4">+38/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>