### PR TITLE
Add avatar upload API and profile preview update

### DIFF
--- a/server/views/profile/profile.handlebars
+++ b/server/views/profile/profile.handlebars
@@ -456,7 +456,12 @@
                             .then(data => {
                                 if (data.success) {
                                     // Update avatar on page
-                                    profileAvatar.src = data.avatarUrl + '?t=' + new Date().getTime();
+                                    const newUrl = data.avatarUrl + '?t=' + new Date().getTime();
+                                    profileAvatar.src = newUrl;
+                                    const smallAvatar = document.querySelector('.user-avatar-small');
+                                    if (smallAvatar) {
+                                        smallAvatar.src = newUrl;
+                                    }
                                 } else {
                                     alert('Failed to upload avatar: ' + data.error);
                                 }


### PR DESCRIPTION
## Summary
- implement avatar upload endpoint under `/api/user/avatar`
- allow users to update avatar image via profile page
- update profile script so avatar preview and nav avatar refresh after upload

## Testing
- `npm test`
- `npm run lint` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f2ba72b6c832f8b6d265f436741a4