### PR TITLE
Update scrapyard queries for new model API

### DIFF
--- a/server/routes/feed.js
+++ b/server/routes/feed.js
@@ -59,11 +59,7 @@ router.get('/', async (req, res, next) => {
         .limit(20)
         .select('username displayName avatar customGlyph statusMessage lastActive'),
         
-      ScrapyardItem.find()
-        .sort({ createdAt: -1 })
-        .limit(20)
-        .populate('creator', 'username displayName avatar customGlyph')
-        .select('title category description previewImage createdAt creator')
+      ScrapyardItem.find({}, { sort: { createdAt: -1 }, limit: 20 })
     ]);
 
     // Add recent user updates to feed
@@ -239,10 +235,10 @@ router.get('/scrapyard/:category', async (req, res, next) => {
     const query = category === 'all' ? {} : { category: category };
     
     // Get recent items
-    const items = await ScrapyardItem.find(query)
-      .sort({ createdAt: -1 })
-      .limit(30)
-      .populate('creator', 'username displayName');
+    const items = await ScrapyardItem.find(query, {
+      sort: { createdAt: -1 },
+      limit: 30
+    });
     
     // Add items to feed
     items.forEach(item => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -139,12 +139,7 @@ router.get('/discover', async (req, res) => {
         .select('username displayName avatar customGlyph statusMessage lastActive'),
 
       // Recent Scrapyard submissions
-      ScrapyardItem.find()
-        .sort({ createdAt: -1 })
-        .skip(skip)
-        .limit(limit)
-        .populate('creator', 'username displayName avatar customGlyph')
-        .select('title category previewImage createdAt creator')
+      ScrapyardItem.find({}, { sort: { createdAt: -1 }, skip, limit })
     ]);
 
     // Count total documents for pagination

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -25,9 +25,10 @@ router.get('/', ensureAuthenticated, async (req, res, next) => {
     const visitors = await Streetpass.getVisitors(user.id, 10);
     
     // User's items in the Scrapyard
-    const userItems = await ScrapyardItem.find({ creator: user._id })
-      .sort({ createdAt: -1 })
-      .limit(5);
+    const userItems = await ScrapyardItem.find(
+      { creator: user._id },
+      { sort: { createdAt: -1 }, limit: 5 }
+    );
     
     res.render('profile/profile', {
       title: `${user.displayName} - Wirebase Profile`,
@@ -67,10 +68,10 @@ router.get('/:username', async (req, res, next) => {
     }
     
     // Get user's items in the Scrapyard
-    const userItems = await ScrapyardItem.find({ creator: profileUser._id })
-      .sort({ createdAt: -1 })
-      .limit(5)
-      .catch(err => {
+    const userItems = await ScrapyardItem.find(
+      { creator: profileUser._id },
+      { sort: { createdAt: -1 }, limit: 5 }
+    ).catch(err => {
         console.error('Failed to fetch user items:', err);
         return []; // Return empty array instead of failing
       });
@@ -185,9 +186,10 @@ router.get('/:username/feed', async (req, res, next) => {
     }
     
     // Find user's items in the Scrapyard
-    const userItems = await ScrapyardItem.find({ creator: user._id })
-      .sort({ createdAt: -1 })
-      .limit(20);
+    const userItems = await ScrapyardItem.find(
+      { creator: user._id },
+      { sort: { createdAt: -1 }, limit: 20 }
+    );
     
     // Create feed
     const feed = new Feed({

--- a/server/routes/scrapyard.js
+++ b/server/routes/scrapyard.js
@@ -64,10 +64,10 @@ const upload = multer({
 // Helper functions for fetching items
 const getTopItems = async (limit = 8) => {
   try {
-    const items = await ScrapyardItem.find()
-      .sort({ usageCount: -1, createdAt: -1 })
-      .limit(limit)
-      .populate('creator', 'username displayName avatar customGlyph');
+    const items = await ScrapyardItem.find(
+      {},
+      { sort: { usageCount: -1, createdAt: -1 }, limit }
+    );
 
     return { rows: items };
   } catch (error) {
@@ -82,10 +82,13 @@ const getRecentItems = async (limit = 12) => {
     const recentItems = {};
 
     for (const category of categories) {
-      recentItems[category] = await ScrapyardItem.find({ category })
-        .sort({ createdAt: -1 })
-        .limit(Math.ceil(limit / categories.length))
-        .populate('creator', 'username displayName avatar customGlyph');
+      recentItems[category] = await ScrapyardItem.find(
+        { category },
+        {
+          sort: { createdAt: -1 },
+          limit: Math.ceil(limit / categories.length)
+        }
+      );
     }
 
     return recentItems;
@@ -97,10 +100,10 @@ const getRecentItems = async (limit = 12) => {
 
 const getFeaturedItems = async (limit = 6) => {
   try {
-    return await ScrapyardItem.find({ featured: true })
-      .sort({ createdAt: -1 })
-      .limit(limit)
-      .populate('creator', 'username displayName avatar customGlyph');
+    return await ScrapyardItem.find(
+      { featured: true },
+      { sort: { createdAt: -1 }, limit }
+    );
   } catch (error) {
     console.error('Error getting featured items:', error);
     return [];
@@ -170,11 +173,10 @@ router.get('/category/:category', async (req, res, next) => {
     const sort = sortOptions[req.query.sort] || sortOptions.newest;
 
     // Query items
-    const items = await ScrapyardItem.find({ category })
-      .sort(sort)
-      .skip(skip)
-      .limit(limit)
-      .populate('creator', 'username displayName avatar customGlyph');
+    const items = await ScrapyardItem.find(
+      { category },
+      { sort, skip, limit }
+    );
 
     // Count total items for pagination
     const total = await ScrapyardItem.countDocuments({ category });
@@ -209,9 +211,7 @@ router.get('/category/:category', async (req, res, next) => {
 router.get('/item/:id', async (req, res, next) => {
   try {
     const { id } = req.params;
-    const item = await ScrapyardItem.findById(id)
-      .populate('creator', 'username displayName avatar customGlyph statusMessage')
-      .populate('comments.user', 'username displayName avatar customGlyph');
+    const item = await ScrapyardItem.findById(id);
 
     if (!item) {
       return res.status(404).render('error', {
@@ -236,13 +236,11 @@ router.get('/item/:id', async (req, res, next) => {
     await ScrapyardItem.findByIdAndUpdate(req.params.id, { $inc: { usageCount: 1 } });
 
     // Get similar items
-    const similarItems = await ScrapyardItem.find({
-      category: item.category,
-      _id: { $ne: item._id }
-    })
-    .sort({ createdAt: -1 })
-    .limit(4)
-    .populate('creator', 'username displayName');
+    let similarItems = await ScrapyardItem.find(
+      { category: item.category },
+      { sort: { createdAt: -1 }, limit: 5 }
+    );
+    similarItems = similarItems.filter(sim => sim.id !== item.id).slice(0, 4);
 
     res.render('scrapyard/item', {
       title: `${item.title} - Wirebase Scrapyard`,
@@ -528,33 +526,26 @@ router.get('/search', async (req, res, next) => {
       return res.redirect('/scrapyard');
     }
 
-    // Build search filter
-    const filter = {
-      $or: [
-        { title: { $regex: query, $options: 'i' } },
-        { description: { $regex: query, $options: 'i' } },
-        { tags: { $regex: query, $options: 'i' } }
-      ]
-    };
-
-    if (category !== 'all') {
-      filter.category = category;
-    }
+    // Build search filter using Supabase's full-text search
 
     // Pagination
     const page = parseInt(req.query.page) || 1;
     const limit = 12;
     const skip = (page - 1) * limit;
 
-    // Execute search
-    const items = await ScrapyardItem.find(filter)
-      .sort({ createdAt: -1 })
-      .skip(skip)
-      .limit(limit)
-      .populate('creator', 'username displayName avatar customGlyph');
+    // Execute search using the new query method
+    const queryOptions = {
+      filter: { search: query },
+      sort: { createdAt: -1 },
+      limit,
+      offset: skip
+    };
+    if (category !== 'all') queryOptions.filter.category = category;
+
+    const items = await ScrapyardItem.query(queryOptions);
 
     // Count total results for pagination
-    const total = await ScrapyardItem.countDocuments(filter);
+    const total = (await ScrapyardItem.query({ filter: queryOptions.filter })).length;
     const totalPages = Math.ceil(total / limit);
 
     res.render('scrapyard/search', {

--- a/server/routes/scrapyard.js
+++ b/server/routes/scrapyard.js
@@ -236,11 +236,13 @@ router.get('/item/:id', async (req, res, next) => {
     await ScrapyardItem.findByIdAndUpdate(req.params.id, { $inc: { usageCount: 1 } });
 
     // Get similar items
-    let similarItems = await ScrapyardItem.find(
-      { category: item.category },
-      { sort: { createdAt: -1 }, limit: 5 }
+    const similarItems = await ScrapyardItem.find(
+      { 
+        category: item.category,
+        _id: { $ne: item._id }
+      },
+      { sort: { createdAt: -1 }, limit: 4 }
     );
-    similarItems = similarItems.filter(sim => sim.id !== item.id).slice(0, 4);
 
     res.render('scrapyard/item', {
       title: `${item.title} - Wirebase Scrapyard`,

--- a/server/routes/scrapyard.js
+++ b/server/routes/scrapyard.js
@@ -545,7 +545,7 @@ router.get('/search', async (req, res, next) => {
     const items = await ScrapyardItem.query(queryOptions);
 
     // Count total results for pagination
-    const total = (await ScrapyardItem.query({ filter: queryOptions.filter })).length;
+    const total = await ScrapyardItem.count({ filter: queryOptions.filter });
     const totalPages = Math.ceil(total / limit);
 
     res.render('scrapyard/search', {


### PR DESCRIPTION
## Summary
- remove populate usage in scrapyard-related routes
- use `ScrapyardItem.find` with filter and options objects
- implement advanced search with `ScrapyardItem.query`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2db785b8832f918761d9d203b40c

## Summary by Sourcery

Update scrapyard-related routes to use the new model API by passing filter and options objects to find(), remove populate usage, and implement advanced search via ScrapyardItem.query

New Features:
- Add advanced search leveraging new ScrapyardItem.query API

Enhancements:
- Replace chained find-sort-limit.populate calls with find(filter, options) across scrapyard, profile, feed, and index routes
- Refactor similar items retrieval to filter and slice results after querying