### PR TITLE
Add Source Code Modal to Item Page

### DIFF
--- a/server/views/market/item.handlebars
+++ b/server/views/market/item.handlebars
@@ -842,7 +842,7 @@
     const viewSourceButton = document.getElementById('view-source-button');
     const sourceCodeModal = document.getElementById('source-code-modal');
 
-    if (viewSourceButton) {
+    if (viewSourceButton && sourceCodeModal) {
       viewSourceButton.addEventListener('click', function(e) {
         e.preventDefault();
         sourceCodeModal.style.display = 'block';

--- a/server/views/market/item.handlebars
+++ b/server/views/market/item.handlebars
@@ -174,7 +174,7 @@
   <div class="modal-content">
     <span class="close-modal">&times;</span>
     <h2>Source Code</h2>
-    <pre><code>{{item.content}}</code></pre>
+    <pre><code>{{htmlEscape item.content}}</code></pre>
   </div>
 </div>
 

--- a/server/views/market/item.handlebars
+++ b/server/views/market/item.handlebars
@@ -169,6 +169,15 @@
   </div>
 </div>
 
+<!-- Source code modal -->
+<div id="source-code-modal" class="modal">
+  <div class="modal-content">
+    <span class="close-modal">&times;</span>
+    <h2>Source Code</h2>
+    <pre><code>{{item.content}}</code></pre>
+  </div>
+</div>
+
 <!-- Purchase confirmation modal -->
 <div id="purchase-modal" class="modal">
   <div class="modal-content">
@@ -828,7 +837,18 @@
         });
       });
     }
-    
+
+    // View source button
+    const viewSourceButton = document.getElementById('view-source-button');
+    const sourceCodeModal = document.getElementById('source-code-modal');
+
+    if (viewSourceButton) {
+      viewSourceButton.addEventListener('click', function(e) {
+        e.preventDefault();
+        sourceCodeModal.style.display = 'block';
+      });
+    }
+
     // Purchase functionality
     const purchaseButton = document.getElementById('purchase-button');
     const purchaseModal = document.getElementById('purchase-modal');


### PR DESCRIPTION
## Summary
- show item's HTML/CSS in a new modal
- trigger the modal by clicking **View Source** button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2daf4a54832fa01056b644201d18

## Summary by Sourcery

Add a modal on the item page to display the item's HTML/CSS source code and enable it via the 'View Source' button

New Features:
- Display an item's HTML/CSS source code in a modal on the item page
- Trigger the source code modal by clicking the 'View Source' button