### PR TITLE
Remove duplicate startServer definition

### DIFF
--- a/server.js
+++ b/server.js
@@ -488,40 +488,6 @@ process.on('SIGINT', gracefulShutdown);
 let healthCheckTimer;
 let leakDetectionTimers;
 
-// Helper function to start the server after verifying DB connection
-let server; // will hold HTTP server instance for graceful shutdown
-
-const startServer = async () => {
-  try {
-    const verified = await verifyDatabaseConnection();
-    if (!verified) {
-      console.error('Database connection could not be verified. Exiting...');
-      process.exit(1);
-    }
-
-    server = app.listen(PORT, () => {
-      console.log(`Wirebase server running in ${NODE_ENV} mode on port ${PORT}`);
-
-      // Start database monitoring after server starts
-      console.log('Starting database monitoring...');
-
-      // Start memory monitor
-      memoryMonitor.start();
-
-      // Start health checks (every 60 seconds)
-      healthCheckTimer = dbHealth.startPeriodicHealthChecks(60000);
-
-      // Start leak detection (check every 30 seconds, fix every 5 minutes)
-      leakDetectionTimers = dbLeakDetector.startLeakDetection(null, 30000, 300000);
-    });
-
-    // Add server timeout to prevent hanging connections
-    server.timeout = 120000; // 2 minutes
-  } catch (err) {
-    console.error('Failed to initialize and start server:', err);
-    process.exit(1);
-  }
-};
 
 // Start server after verifying database connection
 startServer();


### PR DESCRIPTION
### **User description**
## Summary
- delete redundant `startServer` implementation from `server.js`
- keep single call to `startServer()`

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `npm test` *(fails: Jest encountered syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f5dc2df98832f8488095801554785


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate `startServer` function definition

- Keep single function call to maintain server startup


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Duplicate startServer function"] -- "removed" --> B["Single startServer call"]
  B --> C["Clean server.js structure"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Remove duplicate startServer function definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<li>Removed duplicate <code>startServer</code> function implementation (38 lines)<br> <li> Kept the <code>startServer()</code> function call<br> <li> Removed redundant server variable declaration<br> <li> Cleaned up duplicate database verification and server initialization <br>logic


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/115/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+0/-34</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>