### PR TITLE
Fix database connection for Render deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,9 +49,12 @@ const { supabase, supabaseAdmin } = require('./server/utils/database');
 
 // Configure Knex with optimized connection pooling and better error handling
 // Make knex instance globally available for utilities
+// Prefer the full database connection string if provided (e.g. from Render)
+// to avoid constructing credentials manually from Supabase values. This helps
+// prevent connection failures during deployment.
 global.knex = require('knex')({
   client: 'pg',
-  connection: {
+  connection: process.env.DATABASE_URL || {
     host: new URL(process.env.SUPABASE_URL).hostname,
     port: 5432,
     user: 'postgres',


### PR DESCRIPTION
### **User description**
## Summary
- use DATABASE_URL if provided when configuring knex

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc40d571c832fa409cf8e8f5124d9


___

### **PR Type**
Bug fix


___

### **Description**
- Fix database connection for Render deployment

- Use `DATABASE_URL` environment variable when available

- Fallback to manual Supabase credential construction


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Environment Check"] --> B["DATABASE_URL exists?"]
  B -->|Yes| C["Use DATABASE_URL"]
  B -->|No| D["Use Supabase credentials"]
  C --> E["Knex Connection"]
  D --> E["Knex Connection"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Database connection configuration fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<li>Modified knex connection configuration to prioritize <code>DATABASE_URL</code><br> <li> Added fallback to manual Supabase credential construction<br> <li> Added explanatory comments about deployment connection handling


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/wirebase-social/pull/120/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>