### PR TITLE
Add fs import to traffic migration

### DIFF
--- a/scripts/migrations/create-traffic-table.js
+++ b/scripts/migrations/create-traffic-table.js
@@ -3,6 +3,7 @@
  */
 
 const { supabaseAdmin } = require('../../server/utils/database');
+const fs = require('fs');
 
 async function createTrafficTable() {
   try {


### PR DESCRIPTION
## Summary
- include `fs` module in `scripts/migrations/create-traffic-table.js`

## Testing
- `SUPABASE_URL=https://example.supabase.co SUPABASE_KEY=anon SUPABASE_SERVICE_KEY=service SESSION_SECRET=sec node scripts/migrations/create-traffic-table.js` *(fails to connect but no `ReferenceError`)*

------
https://chatgpt.com/codex/tasks/task_e_6860a49a9db8832f9921c85989dc8dae