### PR TITLE
Remove hard‑coded demo credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,20 @@ SUPABASE_KEY=your-anon-key
 SUPABASE_SERVICE_KEY=your-service-role-key
 SESSION_SECRET=your-session-secret
 NODE_ENV=development
+
+# Optional seed user credentials for development
+SEED_ADMIN_USERNAME=admin
+SEED_ADMIN_EMAIL=admin@example.com
+SEED_ADMIN_PASSWORD=changeMe
+SEED_USER_USERNAME=user
+SEED_USER_EMAIL=user@example.com
+SEED_USER_PASSWORD=changeMe
+SEED_USER1_USERNAME=dungeonmaster
+SEED_USER1_EMAIL=master@example.com
+SEED_USER1_PASSWORD=
+SEED_USER2_USERNAME=pixelknight
+SEED_USER2_EMAIL=knight@example.com
+SEED_USER2_PASSWORD=
+SEED_USER3_USERNAME=retroqueen
+SEED_USER3_EMAIL=queen@example.com
+SEED_USER3_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -38,23 +38,6 @@ Visit the live demo at: [https://wirebase.city](https://wirebase.city)
   <img src="docs/screenshots/profile.png" alt="Profile Page" width="45%">
 </div>
 
-## Demo Accounts
-
-You can use these accounts to explore the platform:
-
-- **Username**: DungeonMaster
-  - **Email**: master@wirebase.com
-  - **Password**: password123
-  - **Role**: Admin
-
-- **Username**: PixelKnight
-  - **Email**: knight@wirebase.com
-  - **Password**: password123
-
-- **Username**: RetroQueen
-  - **Email**: queen@wirebase.com
-  - **Password**: password123
-
 ## Local Development
 
 ### Prerequisites
@@ -82,12 +65,29 @@ You can use these accounts to explore the platform:
    SUPABASE_SERVICE_KEY=your-service-role-key
    SESSION_SECRET=your-session-secret
    NODE_ENV=development
+   # Optional seed credentials
+   SEED_ADMIN_USERNAME=admin
+   SEED_ADMIN_EMAIL=admin@example.com
+   SEED_ADMIN_PASSWORD=changeMe
+   SEED_USER_USERNAME=user
+   SEED_USER_EMAIL=user@example.com
+   SEED_USER_PASSWORD=changeMe
+   SEED_USER1_USERNAME=dungeonmaster
+   SEED_USER1_EMAIL=master@example.com
+   SEED_USER1_PASSWORD=
+   SEED_USER2_USERNAME=pixelknight
+   SEED_USER2_EMAIL=knight@example.com
+   SEED_USER2_PASSWORD=
+   SEED_USER3_USERNAME=retroqueen
+   SEED_USER3_EMAIL=queen@example.com
+   SEED_USER3_PASSWORD=
    ```
 
-4. Seed the database with initial data
+4. Seed the database with initial data (optional)
    ```
    node scripts/seed-defaults.js
    ```
+   See [docs/SEEDING.md](docs/SEEDING.md) for guidance on generating secure seed data.
 
 5. Start the development server
    ```

--- a/docs/SEEDING.md
+++ b/docs/SEEDING.md
@@ -1,0 +1,15 @@
+# Secure Seeding Guide
+
+This project supports optional seed scripts for development. Seed users are **not** included by default. To add them, set the environment variables listed in `.env.example` and run:
+
+```bash
+node scripts/seed-defaults.js
+```
+
+Generate strong passwords for the seed accounts. One approach is using `openssl`:
+
+```bash
+openssl rand -base64 32
+```
+
+Store the generated values in your `.env` file and keep that file outside of version control.

--- a/scripts/seed-defaults.js
+++ b/scripts/seed-defaults.js
@@ -3,23 +3,33 @@
  */
 
 const bcrypt = require('bcrypt');
+const dotenv = require('dotenv');
 const { supabaseAdmin } = require('../server/utils/database');
 
+dotenv.config();
+
+const adminUsername = process.env.SEED_ADMIN_USERNAME;
+const adminEmail = process.env.SEED_ADMIN_EMAIL;
+const adminPassword = process.env.SEED_ADMIN_PASSWORD;
+const userUsername = process.env.SEED_USER_USERNAME;
+const userEmail = process.env.SEED_USER_EMAIL;
+const userPassword = process.env.SEED_USER_PASSWORD;
+
 const users = [
-  {
-    username: 'DemoAdmin',
-    email: 'admin@example.com',
-    password: 'password123',
-    displayName: 'Demo Admin',
+  adminUsername && adminEmail && adminPassword && {
+    username: adminUsername,
+    email: adminEmail,
+    password: adminPassword,
+    displayName: process.env.SEED_ADMIN_DISPLAY_NAME || 'Admin',
     role: 'admin'
   },
-  {
-    username: 'DemoUser',
-    email: 'demo@example.com',
-    password: 'password123',
-    displayName: 'Demo User'
+  userUsername && userEmail && userPassword && {
+    username: userUsername,
+    email: userEmail,
+    password: userPassword,
+    displayName: process.env.SEED_USER_DISPLAY_NAME || 'User'
   }
-];
+].filter(Boolean);
 
 const marketItems = [
   {
@@ -29,7 +39,7 @@ const marketItems = [
     content: '<div class="sample-widget">Sample Widget</div>',
     wirPrice: 5,
     tags: ['sample'],
-    creator: 'DemoAdmin'
+    creator: adminUsername
   },
   {
     title: 'Sample Template',
@@ -38,7 +48,7 @@ const marketItems = [
     content: '<div class="sample-template">Template</div>',
     wirPrice: 0,
     tags: ['template'],
-    creator: 'DemoUser'
+    creator: userUsername
   }
 ];
 

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -15,12 +15,27 @@ dotenv.config();
 const User = require('../server/models/User');
 const ScrapyardItem = require('../server/models/ScrapyardItem');
 
-// Demo users data
-const users = [
-  {
-    username: 'DungeonMaster',
-    email: 'master@wirebase.com',
-    password: 'password123',
+// Load user credentials from environment variables
+const user1Username = process.env.SEED_USER1_USERNAME || 'DungeonMaster';
+const user1Email = process.env.SEED_USER1_EMAIL || 'master@wirebase.com';
+const user1Password = process.env.SEED_USER1_PASSWORD;
+
+const user2Username = process.env.SEED_USER2_USERNAME || 'PixelKnight';
+const user2Email = process.env.SEED_USER2_EMAIL || 'knight@wirebase.com';
+const user2Password = process.env.SEED_USER2_PASSWORD;
+
+const user3Username = process.env.SEED_USER3_USERNAME || 'RetroQueen';
+const user3Email = process.env.SEED_USER3_EMAIL || 'queen@wirebase.com';
+const user3Password = process.env.SEED_USER3_PASSWORD;
+
+// Configurable users data (only seeded when password env vars are present)
+const users = [];
+
+if (user1Username && user1Email && user1Password) {
+  users.push({
+    username: user1Username,
+    email: user1Email,
+    password: user1Password,
     displayName: 'Dungeon Master',
     customGlyph: '🧙',
     statusMessage: 'Keeper of the code realm',
@@ -64,11 +79,14 @@ const users = [
         description: 'Expert coder and HTML wizard'
       }
     ]
-  },
-  {
-    username: 'PixelKnight',
-    email: 'knight@wirebase.com',
-    password: 'password123',
+  });
+}
+
+if (user2Username && user2Email && user2Password) {
+  users.push({
+    username: user2Username,
+    email: user2Email,
+    password: user2Password,
     displayName: 'Pixel Knight',
     customGlyph: '⚔️',
     statusMessage: 'Defender of pixel perfection',
@@ -114,11 +132,14 @@ const users = [
     .shield { background-color: #4b2883; }
     .potion { background-color: #ff7f00; }`,
     lootTokens: 350
-  },
-  {
-    username: 'RetroQueen',
-    email: 'queen@wirebase.com',
-    password: 'password123',
+  });
+}
+
+if (user3Username && user3Email && user3Password) {
+  users.push({
+    username: user3Username,
+    email: user3Email,
+    password: user3Password,
     displayName: 'Retro Queen',
     customGlyph: '👑',
     statusMessage: 'Windows 98 forever!',
@@ -184,8 +205,8 @@ const users = [
       margin-top: 10px;
     }`,
     lootTokens: 280
-  }
-];
+  });
+}
 
 // Sample Scrapyard items
 const scrapyardItems = [


### PR DESCRIPTION
## Summary
- load seed users from environment variables
- document secure seeding setup
- remove credentials from README and .env example

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c5877a6ec832fada6858f3645d412