### PR TITLE
Wrap minimal-server request logs with logger

### DIFF
--- a/minimal-server.js
+++ b/minimal-server.js
@@ -161,8 +161,11 @@ const server = http.createServer((req, res) => {
   const parsedUrl = url.parse(req.url, true);
   const pathname = parsedUrl.pathname;
 
-  // Log all requests
-  if (process.env.DEBUG) logger.debug(`Request: ${req.method} ${pathname}`);
+  // Log all requests using the shared logger
+  // Disabled by default when NODE_ENV is 'production'
+  if (process.env.LOG_REQUESTS === 'true' || process.env.NODE_ENV !== 'production') {
+    logger.debug(`Request: ${req.method} ${pathname}`);
+  }
 
   // Special case for favicon
   if (req.method === 'GET' && pathname === '/favicon.ico') {


### PR DESCRIPTION
## Summary
- wrap request logging in `minimal-server.js` with the shared logger
- disable request logging by default when running in production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c6b275970832fa0a713e17e65c26b