### PR TITLE
Remove demo threads and implement server-driven sorting

### DIFF
--- a/server/models/Thread.js
+++ b/server/models/Thread.js
@@ -177,7 +177,27 @@ class Thread {
           break;
         default:
           regular.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-      }
+replies:forum_replies (id)
+        `, { count: 'exact' })
+        .eq('category', category)
+        .order('is_pinned', { ascending: false })
+        .order(sort === 'oldest' ? 'created_at' : sort === 'replies' ? 'reply_count' : sort === 'activity' ? 'updated_at' : 'created_at', { ascending: sort === 'oldest' })
+        .range(offset, offset + limit - 1);
+
+      if (error) throw error;
+
+      // Format the threads data
+      const formattedThreads = threads.map(thread => ({
+        ...this.formatThread(thread),
+        replyCount: thread.replies ? thread.replies.length : 0
+      }));
+
+      const result = {
+        threads: formattedThreads,
+        total: count || 0
+      };
+
+      // Cache the result
 
       const sortedThreads = [...pinned, ...regular];
 

--- a/server/models/Thread.js
+++ b/server/models/Thread.js
@@ -150,7 +150,16 @@ class Thread {
         `, { count: 'exact' })
         .eq('category', category)
         .order('is_pinned', { ascending: false })
-        .range(offset, offset + limit - 1);
+      // For 'replies', we sort in JS. This is only sorting the current page.
+      // For accurate global sorting by replies, consider adding a `reply_count`
+      // column to the `forum_threads` table and updating it with a trigger.
+      let sortedThreads = formattedThreads;
+      if (sort === 'replies') {
+        const pinned = formattedThreads.filter(t => t.isPinned);
+        const regular = formattedThreads.filter(t => !t.isPinned);
+        regular.sort((a, b) => b.replyCount - a.replyCount);
+        sortedThreads = [...pinned, ...regular];
+      }
 
       if (error) throw error;
 

--- a/server/models/Thread.js
+++ b/server/models/Thread.js
@@ -351,7 +351,21 @@ class Thread {
       sorts.forEach(sort => {
         cache.del(`threads:category:${category}:20:${i}:${sort}`);
       });
-    }
+static clearCategoryCache(category) {
+    // Clear all possible cache entries for this category
+    const sorts = ['newest', 'oldest', 'replies', 'activity'];
+    const limits = [20, 50, 100]; // Adjust based on actual usage
+    limits.forEach(limit => {
+      for (let offset = 0; offset < 100; offset += limit) {
+        cache.del(`threads:category:${category}:${limit}:${offset}`);
+        sorts.forEach(sort => {
+          cache.del(`threads:category:${category}:${limit}:${offset}:${sort}`);
+        });
+      }
+    });
+  }
+
+  /**
   }
 
   /**

--- a/server/routes/forum.js
+++ b/server/routes/forum.js
@@ -66,6 +66,7 @@ router.get('/category/:category', async (req, res) => {
   try {
     const { category } = req.params;
     const page = parseInt(req.query.page) || 1;
+    const sort = req.query.sort || 'newest';
     const limit = 20;
     const offset = (page - 1) * limit;
 
@@ -85,8 +86,8 @@ router.get('/category/:category', async (req, res) => {
       });
     }
 
-    // Get threads for this category
-    const { threads, total } = await Thread.getByCategory(category, limit, offset);
+    // Get threads for this category with sorting
+    const { threads, total } = await Thread.getByCategory(category, limit, offset, sort);
 
     // Calculate pagination
     const totalPages = Math.ceil(total / limit);
@@ -112,6 +113,7 @@ router.get('/category/:category', async (req, res) => {
       categoryInfo,
       threads,
       pagination,
+      sort,
       pageDescription: `Discussions in the ${category} category`,
       pageTheme: 'dark-dungeon',
       additionalStyles: ['/css/forum.css'],

--- a/server/views/forum/category.handlebars
+++ b/server/views/forum/category.handlebars
@@ -67,119 +67,59 @@
     <div class="cyber-window-header">
       <span class="cyber-window-title">Threads</span>
       <div class="thread-sort-controls">
-        <label for="thread-sort">Sort by:</label>
-        <select id="thread-sort" class="cyber-select">
-          <option value="newest">Newest</option>
-          <option value="oldest">Oldest</option>
-          <option value="replies">Most Replies</option>
-          <option value="activity">Recent Activity</option>
-        </select>
+        <form id="sort-form" method="get">
+          <input type="hidden" name="page" value="{{pagination.currentPage}}">
+          <label for="thread-sort">Sort by:</label>
+          <select id="thread-sort" name="sort" class="cyber-select">
+            <option value="newest" {{#if (eq sort 'newest')}}selected{{/if}}>Newest</option>
+            <option value="oldest" {{#if (eq sort 'oldest')}}selected{{/if}}>Oldest</option>
+            <option value="replies" {{#if (eq sort 'replies')}}selected{{/if}}>Most Replies</option>
+            <option value="activity" {{#if (eq sort 'activity')}}selected{{/if}}>Recent Activity</option>
+          </select>
+        </form>
       </div>
     </div>
     <div class="cyber-window-content">
       <div class="thread-list">
-        <!-- In a real app, this would be populated with actual threads -->
-        {{#if (eq category "general")}}
-          <div class="thread-item pinned">
-            <div class="pin-indicator" title="Pinned Thread">📌</div>
-            <div class="thread-title">
-              <a href="/forum/thread/1">Welcome to the Wirebase Assembly</a>
+        {{#if threads.length}}
+          {{#each threads}}
+            <div class="thread-item {{#if isPinned}}pinned{{/if}}">
+              {{#if isPinned}}
+                <div class="pin-indicator" title="Pinned Thread">📌</div>
+              {{/if}}
+              <div class="thread-title">
+                <a href="/forum/thread/{{id}}">{{title}}</a>
+              </div>
+              <div class="thread-meta">
+                <span class="thread-author">{{creator.username}}</span>
+                <span class="thread-date">{{formatDate createdAt 'relative'}}</span>
+                <span class="thread-replies">{{replyCount}} {{#if (eq replyCount 1)}}reply{{else}}replies{{/if}}</span>
+              </div>
+              {{#if tags.length}}
+                <div class="thread-tags">
+                  {{#each tags}}
+                    <span class="thread-tag">{{this}}</span>
+                  {{/each}}
+                </div>
+              {{/if}}
             </div>
-            <div class="thread-meta">
-              <span class="thread-author">system_admin</span>
-              <span class="thread-date">2 days ago</span>
-              <span class="thread-replies">5 replies</span>
-            </div>
+          {{/each}}
+        {{else}}
+          <div class="no-threads">
+            <p>No threads found. Be the first to create a thread!</p>
           </div>
         {{/if}}
-
-        {{#if (eq category "tech")}}
-          <div class="thread-item pinned">
-            <div class="pin-indicator" title="Pinned Thread">📌</div>
-            <div class="thread-title">
-              <a href="/forum/thread/2">Technical FAQ and Resources</a>
-            </div>
-            <div class="thread-meta">
-              <span class="thread-author">tech_support</span>
-              <span class="thread-date">1 day ago</span>
-              <span class="thread-replies">3 replies</span>
-            </div>
-          </div>
-        {{/if}}
-
-        {{#if (eq category "creative")}}
-          <div class="thread-item">
-            <div class="thread-title">
-              <a href="/forum/thread/3">Share Your Wirebase Profile Designs</a>
-            </div>
-            <div class="thread-meta">
-              <span class="thread-author">design_guru</span>
-              <span class="thread-date">12 hours ago</span>
-              <span class="thread-replies">7 replies</span>
-            </div>
-          </div>
-        {{/if}}
-
-        {{#if (eq category "meta")}}
-          <div class="thread-item">
-            <div class="thread-title">
-              <a href="/forum/thread/4">Feature Request: Enhanced Terminal Mode</a>
-            </div>
-            <div class="thread-meta">
-              <span class="thread-author">power_user</span>
-              <span class="thread-date">5 hours ago</span>
-              <span class="thread-replies">2 replies</span>
-            </div>
-          </div>
-        {{/if}}
-
-        <!-- Add some placeholder threads for all categories -->
-        <div class="thread-item">
-          <div class="thread-title">
-            <a href="/forum/thread/5">Example Thread in {{category}}</a>
-          </div>
-          <div class="thread-meta">
-            <span class="thread-author">user123</span>
-            <span class="thread-date">3 hours ago</span>
-            <span class="thread-replies">0 replies</span>
-          </div>
-        </div>
-
-        <div class="thread-item">
-          <div class="thread-title">
-            <a href="/forum/thread/6">Another Example Thread in {{category}}</a>
-          </div>
-          <div class="thread-meta">
-            <span class="thread-author">wirebase_fan</span>
-            <span class="thread-date">1 hour ago</span>
-            <span class="thread-replies">1 reply</span>
-          </div>
-        </div>
-
-        <!-- Generate more example threads for pagination demo -->
-        {{#each (range 7 15)}}
-          <div class="thread-item">
-            <div class="thread-title">
-              <a href="/forum/thread/{{this}}">Thread #{{this}} in {{../category}}</a>
-            </div>
-            <div class="thread-meta">
-              <span class="thread-author">user{{this}}</span>
-              <span class="thread-date">{{subtract this 6}} hours ago</span>
-              <span class="thread-replies">{{subtract this 7}} replies</span>
-            </div>
-          </div>
-        {{/each}}
       </div>
 
       <!-- Pagination -->
       <div class="pagination">
-        <a href="?page=1" class="cyber-button pagination-button {{#if (eq currentPage 1)}}disabled{{/if}}">First</a>
-        <a href="?page={{subtract currentPage 1}}" class="cyber-button pagination-button {{#if (eq currentPage 1)}}disabled{{/if}}">Previous</a>
+        <a href="?page=1&sort={{sort}}" class="cyber-button pagination-button {{#if (eq pagination.currentPage 1)}}disabled{{/if}}">First</a>
+        <a href="?page={{subtract pagination.currentPage 1}}&sort={{sort}}" class="cyber-button pagination-button {{#if (eq pagination.currentPage 1)}}disabled{{/if}}">Previous</a>
 
-        <div class="pagination-info">Page {{currentPage}} of {{totalPages}}</div>
+        <div class="pagination-info">Page {{pagination.currentPage}} of {{pagination.totalPages}}</div>
 
-        <a href="?page={{add currentPage 1}}" class="cyber-button pagination-button {{#if (eq currentPage totalPages)}}disabled{{/if}}">Next</a>
-        <a href="?page={{totalPages}}" class="cyber-button pagination-button {{#if (eq currentPage totalPages)}}disabled{{/if}}">Last</a>
+        <a href="?page={{add pagination.currentPage 1}}&sort={{sort}}" class="cyber-button pagination-button {{#if (eq pagination.currentPage pagination.totalPages)}}disabled{{/if}}">Next</a>
+        <a href="?page={{pagination.totalPages}}&sort={{sort}}" class="cyber-button pagination-button {{#if (eq pagination.currentPage pagination.totalPages)}}disabled{{/if}}">Last</a>
       </div>
     </div>
   </div>
@@ -194,91 +134,12 @@
       header.setAttribute('data-text', text);
     });
 
-    // Thread sorting functionality
+    // Submit sort form when option changes
     const threadSortSelect = document.getElementById('thread-sort');
-    const threadList = document.querySelector('.thread-list');
-    const threadItems = Array.from(document.querySelectorAll('.thread-item'));
-
-    if (threadSortSelect && threadList) {
+    if (threadSortSelect) {
       threadSortSelect.addEventListener('change', function() {
-        const sortBy = this.value;
-
-        // Clone the thread items for sorting
-        const sortedItems = [...threadItems];
-
-        // Sort the items based on the selected option
-        switch(sortBy) {
-          case 'newest':
-            sortedItems.sort((a, b) => {
-              const dateA = a.querySelector('.thread-date').textContent;
-              const dateB = b.querySelector('.thread-date').textContent;
-              // Simple comparison for demo purposes
-              // In a real app, you'd parse actual dates
-              return dateA.localeCompare(dateB);
-            });
-            break;
-
-          case 'oldest':
-            sortedItems.sort((a, b) => {
-              const dateA = a.querySelector('.thread-date').textContent;
-              const dateB = b.querySelector('.thread-date').textContent;
-              return dateB.localeCompare(dateA);
-            });
-            break;
-
-          case 'replies':
-            sortedItems.sort((a, b) => {
-              const repliesA = parseInt(a.querySelector('.thread-replies').textContent);
-              const repliesB = parseInt(b.querySelector('.thread-replies').textContent);
-              return repliesB - repliesA; // Most replies first
-            });
-            break;
-
-          case 'activity':
-            // For demo purposes, we'll just use a random sort
-            sortedItems.sort(() => Math.random() - 0.5);
-            break;
-        }
-
-        // Move pinned threads to the top regardless of sort
-        const pinnedItems = sortedItems.filter(item => item.classList.contains('pinned'));
-        const regularItems = sortedItems.filter(item => !item.classList.contains('pinned'));
-        const finalSortedItems = [...pinnedItems, ...regularItems];
-
-        // Clear the thread list
-        threadList.innerHTML = '';
-
-        // Append the sorted items
-        finalSortedItems.forEach(item => {
-          threadList.appendChild(item);
-        });
+        document.getElementById('sort-form').submit();
       });
-    }
-
-    // Pagination functionality
-    const paginationButtons = document.querySelectorAll('.pagination-button');
-
-    paginationButtons.forEach(button => {
-      if (!button.classList.contains('disabled')) {
-        button.addEventListener('click', function(e) {
-          // In a real app, this would navigate to the page
-          // For demo purposes, we'll just show an alert
-          const href = this.getAttribute('href');
-          const page = href.split('=')[1];
-
-          alert(`Navigating to page ${page}`);
-
-          // Prevent default to avoid actual navigation in demo
-          e.preventDefault();
-        });
-      }
-    });
-
-    // Set default values for pagination demo
-    const paginationInfo = document.querySelector('.pagination-info');
-    if (paginationInfo) {
-      // Set current page to 1 and total pages to 5 for demo
-      paginationInfo.textContent = paginationInfo.textContent.replace('{{currentPage}}', '1').replace('{{totalPages}}', '5');
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- clean up category page threads: remove demo placeholders
- remove client-side demo sorting/pagination logic
- enable real sorting via query parameters
- fetch sorted threads server-side

## Testing
- `npm test`
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c6b37f03c832fa87644fd0106ffcc

## Summary by Sourcery

Implement server-driven thread sorting and clean up demo placeholders by removing client-side sorting and rendering actual threads dynamically with updated caching and routing.

New Features:
- Support sorting threads by newest, oldest, most replies, or recent activity via a query parameter
- Add a sort form in the UI that submits the selected sort option and includes it in pagination links

Enhancements:
- Remove demo placeholder threads and client-side sorting/pagination logic
- Fetch and render real threads in the template with dynamic metadata and tags
- Extend getByCategory to accept a sort parameter, apply server-side sorting, and include sort in cache keys and cache clearing